### PR TITLE
Rename func sub_43E770 to object_move_to_location.

### DIFF
--- a/src/game/ai.c
+++ b/src/game/ai.c
@@ -2680,7 +2680,7 @@ bool ai_waypoints_process(int64_t obj, bool a2)
     if (a2) {
         if (next_map == map) {
             sub_424070(obj, 4, false, true);
-            sub_43E770(obj, next_loc, 0, 0);
+            object_move_to_location(obj, next_loc, 0, 0);
         } else {
             teleport_data.flags = 0;
             teleport_data.map = next_map;
@@ -2791,7 +2791,7 @@ bool ai_standpoints_process(int64_t obj, bool a2)
     if (a2) {
         if (next_map == map) {
             sub_424070(obj, 4, 0, 1);
-            sub_43E770(obj, standpoint_loc, 0, 0);
+            object_move_to_location(obj, standpoint_loc, 0, 0);
         } else {
             teleport_data.flags = 0;
             teleport_data.map = next_map;
@@ -3041,7 +3041,7 @@ bool sub_4AD4D0(int64_t obj)
     }
 
     sub_424070(obj, 4, false, true);
-    sub_43E770(obj, obj_field_int64_get(pc_leader_obj, OBJ_F_LOCATION), 0, 0);
+    object_move_to_location(obj, obj_field_int64_get(pc_leader_obj, OBJ_F_LOCATION), 0, 0);
 
     return true;
 }

--- a/src/game/anim.c
+++ b/src/game/anim.c
@@ -8496,7 +8496,7 @@ void anim_goal_reset_position_mp(AnimID* anim_id, int64_t obj, int64_t loc, tig_
         object_set_current_aid(obj, art_id);
     }
 
-    sub_43E770(obj, loc, offset_x, offset_y);
+    object_move_to_location(obj, loc, offset_x, offset_y);
 
     if (anim_id_to_run_info(anim_id, &run_info)) {
         run_info->flags = flags;
@@ -10493,7 +10493,7 @@ bool sub_42E9B0(AnimRunInfo* run_info)
             }
         }
 
-        sub_43E770(obj, loc, 0, 0);
+        object_move_to_location(obj, loc, 0, 0);
         run_info->cur_stack_data->params[AGDATA_TARGET_TILE].loc = loc;
         run_info->goals[0].params[AGDATA_TARGET_TILE].loc = loc;
 
@@ -10694,7 +10694,7 @@ bool sub_42F000(AnimRunInfo* run_info)
         return false;
     }
 
-    sub_43E770(obj, loc, offset_x - x_shifts[rot], offset_y - y_shifts[rot]);
+    object_move_to_location(obj, loc, offset_x - x_shifts[rot], offset_y - y_shifts[rot]);
 
     return true;
 }
@@ -10844,7 +10844,7 @@ bool sub_42F390(AnimRunInfo* run_info)
             offset_y += (int)(loc_y - new_loc_y);
         }
 
-        sub_43E770(obj, new_loc, offset_x, offset_y);
+        object_move_to_location(obj, new_loc, offset_x, offset_y);
 
         run_info->path.curr += 2;
 
@@ -10979,7 +10979,7 @@ bool sub_42F6A0(AnimRunInfo* run_info)
             offset_y += (int)(projectile_loc_y - new_loc_y);
         }
 
-        sub_43E770(projectile_obj, new_loc, offset_x, offset_y);
+        object_move_to_location(projectile_obj, new_loc, offset_x, offset_y);
 
         run_info->path.curr += 2;
 
@@ -11042,7 +11042,7 @@ bool sub_42FA50(AnimRunInfo* run_info)
 
         if (new_loc != loc) {
             if (sub_42FD70(run_info, obj, &(run_info->path), loc, new_loc)) {
-                sub_43E770(obj, loc, 0, 0);
+                object_move_to_location(obj, loc, 0, 0);
                 sub_4B2210(OBJ_HANDLE_NULL, obj, &combat);
                 combat.dam[DAMAGE_TYPE_NORMAL] = random_between(1, (run_info->path.max - run_info->path.curr) / 2);
                 combat.dam[DAMAGE_TYPE_FATIGUE] = random_between(1, (run_info->path.max - run_info->path.curr) / 2);
@@ -11061,7 +11061,7 @@ bool sub_42FA50(AnimRunInfo* run_info)
             offset_y += (int)(loc_y - new_loc_y);
         }
 
-        sub_43E770(obj, new_loc, offset_x, offset_y);
+        object_move_to_location(obj, new_loc, offset_x, offset_y);
 
         run_info->path.curr += 2;
         if (run_info->path.curr >= run_info->path.max) {
@@ -11634,7 +11634,7 @@ bool sub_4305D0(AnimRunInfo* run_info)
                 offset_y += 2 * v2 - 15;
             }
 
-            sub_43E770(obj, new_loc, offset_x, offset_y);
+            object_move_to_location(obj, new_loc, offset_x, offset_y);
             run_info->path.flags |= 0x02;
 
             if (tig_net_is_active()

--- a/src/game/critter.c
+++ b/src/game/critter.c
@@ -2044,7 +2044,7 @@ bool critter_enter_bed(int64_t obj, int64_t bed)
     obj_location = obj_field_int64_get(bed, OBJ_F_LOCATION);
     if (bed_location == obj_location
         && location_in_dir(obj_location, 4, &location)) {
-        sub_43E770(obj, location, 0, 0);
+        object_move_to_location(obj, location, 0, 0);
     }
 
     return true;

--- a/src/game/item.c
+++ b/src/game/item.c
@@ -2056,7 +2056,7 @@ void sub_463C60(int64_t obj)
             return;
         }
 
-        object_get_rect(obj, 0x08, &obj_rect);
+        object_get_rect(obj, RECT_FLAG_IGNORE_VIS, &obj_rect);
 
         if (obj_rect.x >= item_iso_content_rect.x + item_iso_content_rect.width
             || obj_rect.y >= item_iso_content_rect.height + item_iso_content_rect.y

--- a/src/game/light.c
+++ b/src/game/light.c
@@ -1184,7 +1184,7 @@ void sub_4DC210(int64_t obj, int* colors, int* cnt_ptr)
         tig_art_wall_id_p_piece_get(art_id);
 
         TigRect obj_rect;
-        object_get_rect(obj, 0, &obj_rect);
+        object_get_rect(obj, RECT_FLAG_NONE, &obj_rect);
 
         loc_y += (obj_rect.x - loc_x) * v1;
         loc_x = obj_rect.x;

--- a/src/game/magictech.c
+++ b/src/game/magictech.c
@@ -4318,7 +4318,7 @@ void sub_455350(int64_t obj, int64_t target_loc)
         }
 
         sub_424070(obj, 5, false, true);
-        sub_43E770(obj, source_loc, 0, 0);
+        object_move_to_location(obj, source_loc, 0, 0);
 
         if (player_is_local_pc_obj(obj)) {
             location_origin_set(source_loc);

--- a/src/game/monstergen.c
+++ b/src/game/monstergen.c
@@ -342,7 +342,7 @@ bool monstergen_process(int64_t obj, DateTime* datetime)
         // NOTE: This condition might pose a problem on certain maps on very
         // high resolutions.
         if ((generator_info.flags & GENERATOR_INACTIVE_ON_SCREEN) != 0) {
-            object_get_rect(obj, 0x8, &rect);
+            object_get_rect(obj, RECT_FLAG_IGNORE_VIS, &rect);
             if (rect.x < monstergen_iso_content_rect.width + monstergen_iso_content_rect.x
                 && rect.y < monstergen_iso_content_rect.height + monstergen_iso_content_rect.y
                 && monstergen_iso_content_rect.x < rect.x + rect.width
@@ -427,7 +427,7 @@ int monstergen_generate(GeneratorInfo* generator_info, int cnt)
     art_id = tile_art_id_at(loc);
     tile_type = tig_art_tile_id_type_get(art_id);
     location_xy(loc, &x, &y);
-    object_get_rect(generator_info->obj, 0x8, &rect);
+    object_get_rect(generator_info->obj, RECT_FLAG_IGNORE_VIS, &rect);
 
     num_generated = 0;
     while (num_generated < cnt) {

--- a/src/game/mp_utils.c
+++ b/src/game/mp_utils.c
@@ -334,7 +334,7 @@ void sub_4EDF20(int64_t obj, int64_t location, int dx, int dy, bool a7)
         if (a7 && player_is_local_pc_obj(obj)) {
             location_origin_set(location);
         }
-        sub_43E770(obj, location, dx, dy);
+        object_move_to_location(obj, location, dx, dy);
     }
 
     if (tig_net_is_active()
@@ -356,7 +356,7 @@ void sub_4EDFF0(Packet99* pkt)
 
     if (tig_net_is_host()) {
         obj = objp_perm_lookup(pkt->oid);
-        sub_43E770(obj, pkt->location, pkt->dx, pkt->dy);
+        object_move_to_location(obj, pkt->location, pkt->dx, pkt->dy);
 
         if (pkt->field_30 && player_is_local_pc_obj(obj)) {
             location_origin_set(pkt->location);

--- a/src/game/multiplayer.c
+++ b/src/game/multiplayer.c
@@ -977,7 +977,7 @@ void multiplayer_handle_message(void* msg)
 void sub_4A1F30(int64_t obj, int64_t location, int dx, int dy)
 {
     if (location != 0) {
-        sub_43E770(obj, location, dx, dy);
+        object_move_to_location(obj, location, dx, dy);
     }
 }
 

--- a/src/game/object.c
+++ b/src/game/object.c
@@ -427,7 +427,7 @@ void object_ping(tig_timestamp_t timestamp)
                                     render_flags = obj_field_int32_get(obj_node->obj, OBJ_F_RENDER_FLAGS);
                                     render_flags &= ~(ORF_02000000 | ORF_04000000);
                                     obj_field_int32_set(obj_node->obj, OBJ_F_RENDER_FLAGS, render_flags);
-                                    object_get_rect(obj_node->obj, 0x07, &obj_rect);
+                                    object_get_rect(obj_node->obj, RECT_FLAG_FULL, &obj_rect);
                                     object_iso_invalidate_rect(&obj_rect);
                                     obj_node = obj_node->next;
                                 }
@@ -770,7 +770,7 @@ void object_draw(GameDrawInfo* draw_info)
                                                         }
                                                     }
 
-                                                    object_get_rect(obj_node->obj, 0, &eye_candy_rect);
+                                                    object_get_rect(obj_node->obj, RECT_FLAG_NONE, &eye_candy_rect);
 
                                                     v71 = false;
                                                     if ((obj_flags & OF_WADING) != 0 && (obj_flags & OF_WATER_WALKING) == 0) {
@@ -1072,7 +1072,7 @@ void sub_43C690(GameDrawInfo* draw_info)
             return;
         }
 
-        object_get_rect(object_hover_obj, 0, &obj_rect);
+        object_get_rect(object_hover_obj, RECT_FLAG_NONE, &obj_rect);
 
         if ((flags & OF_WADING) != 0 && (flags & OF_WATER_WALKING) == 0) {
             tmp_rect = obj_rect;
@@ -1252,7 +1252,7 @@ void object_destroy(int64_t obj)
 
     multiplayer_lock();
 
-    object_get_rect(obj, 0x7, &rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &rect);
     object_iso_invalidate_rect(&rect);
 
     obj_type = obj_field_int32_get(obj, OBJ_F_TYPE);
@@ -1307,7 +1307,7 @@ void sub_43CEA0(int64_t obj, unsigned int flags, const char* path)
     TigRect rect;
     int type;
 
-    object_get_rect(obj, 0x7, &rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &rect);
     object_iso_invalidate_rect(&rect);
 
     sub_463B30(obj, false);
@@ -1388,7 +1388,7 @@ void object_flags_set(int64_t obj, unsigned int flags)
         flags &= ~OF_FLAT;
     }
 
-    object_get_rect(obj, 0x7, &rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &rect);
     object_iso_invalidate_rect(&rect);
 
     cur_flags = obj_field_int32_get(obj, OBJ_F_FLAGS);
@@ -1445,7 +1445,7 @@ void object_flags_set(int64_t obj, unsigned int flags)
         OBJ_F_RENDER_FLAGS,
         obj_field_int32_get(obj, OBJ_F_RENDER_FLAGS) & ~render_flags);
 
-    object_get_rect(obj, 0x7, &rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &rect);
     object_iso_invalidate_rect(&rect);
 }
 
@@ -1464,7 +1464,7 @@ void object_flags_unset(int64_t obj, unsigned int flags)
         flags &= ~OF_FLAT;
     }
 
-    object_get_rect(obj, 0x7, &rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &rect);
     object_iso_invalidate_rect(&rect);
 
     cur_flags = obj_field_int32_get(obj, OBJ_F_FLAGS);
@@ -1515,7 +1515,7 @@ void object_flags_unset(int64_t obj, unsigned int flags)
         OBJ_F_RENDER_FLAGS,
         obj_field_int32_get(obj, OBJ_F_RENDER_FLAGS) & ~render_flags);
 
-    object_get_rect(obj, 0x7, &rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &rect);
     object_iso_invalidate_rect(&rect);
 
     if (visibility_changed) {
@@ -1774,9 +1774,9 @@ bool sub_43D9F0(int x, int y, int64_t* obj_ptr, unsigned int flags)
     SomeSectorStuffEntry* v3;
     int row;
     int col;
-    int indexes[3];
-    int widths[3];
-    bool locks[3];
+    int indexes[3] = { 0 };
+    int widths[3] = { 0 };
+    bool locks[3] = { false };
     Sector* sectors[3];
     int64_t v65;
     int64_t v67;
@@ -1850,7 +1850,7 @@ bool sub_43D9F0(int x, int y, int64_t* obj_ptr, unsigned int flags)
                                 }
                             }
 
-                            object_get_rect(obj_node->obj, 0, &obj_rect);
+                            object_get_rect(obj_node->obj, RECT_FLAG_NONE, &obj_rect);
 
                             aid = obj_field_int32_get(obj_node->obj, OBJ_F_CURRENT_AID);
                             scale = obj_field_int32_get(obj_node->obj, OBJ_F_BLIT_SCALE);
@@ -1982,7 +1982,7 @@ void object_get_rect(int64_t obj, unsigned int flags, TigRect* rect)
     TigRect extra_rect;
 
     obj_flags = obj_field_int32_get(obj, OBJ_F_FLAGS);
-    if ((flags & 0x8) == 0 && (obj_flags & dword_5E2F88) != 0) {
+    if ((flags & RECT_FLAG_IGNORE_VIS) == 0 && (obj_flags & dword_5E2F88) != 0) {
         rect->x = 0;
         rect->y = 0;
         rect->width = 0;
@@ -2077,8 +2077,8 @@ void object_get_rect(int64_t obj, unsigned int flags, TigRect* rect)
     rect->width = width;
     rect->height = height;
 
-    if (flags != 0) {
-        if ((flags & 0x2) != 0 && (obj_flags & OF_HAS_OVERLAYS) != 0) {
+    if (flags != RECT_FLAG_NONE) {
+        if ((flags & RECT_FLAG_OVERLAYS) != 0 && (obj_flags & OF_HAS_OVERLAYS) != 0) {
             for (int fld = OBJ_F_OVERLAY_FORE; fld <= OBJ_F_OVERLAY_BACK; fld++) {
                 for (idx = 0; idx < 7; idx++) {
                     tig_art_id_t art_id = obj_arrayfield_uint32_get(obj, fld, idx);
@@ -2118,7 +2118,7 @@ void object_get_rect(int64_t obj, unsigned int flags, TigRect* rect)
             }
         }
 
-        if ((flags & 0x4) != 0 && (obj_flags & OF_HAS_UNDERLAYS) != 0) {
+        if ((flags & RECT_FLAG_UNDERLAYS) != 0 && (obj_flags & OF_HAS_UNDERLAYS) != 0) {
             for (idx = 0; idx < 4; idx++) {
                 tig_art_id_t art_id = obj_arrayfield_uint32_get(obj, OBJ_F_UNDERLAY, idx);
                 if (art_id != TIG_ART_ID_INVALID
@@ -2139,7 +2139,7 @@ void object_get_rect(int64_t obj, unsigned int flags, TigRect* rect)
             }
         }
 
-        if ((flags & 0x1) != 0) {
+        if ((flags & RECT_FLAG_SHADOWS) != 0) {
             render_flags = obj_field_int32_get(obj, OBJ_F_RENDER_FLAGS);
             if ((render_flags & ORF_04000000) == 0) {
                 if (shadow_apply(obj)) {
@@ -2198,7 +2198,7 @@ void object_get_rect(int64_t obj, unsigned int flags, TigRect* rect)
 }
 
 // 0x43E770
-void sub_43E770(int64_t obj, int64_t loc, int offset_x, int offset_y)
+void object_move_to_location(int64_t obj, int64_t loc, int offset_x, int offset_y)
 {
     unsigned int flags;
     int64_t cur_loc;
@@ -2227,7 +2227,7 @@ void sub_43E770(int64_t obj, int64_t loc, int offset_x, int offset_y)
         tf_notify_moved(obj, loc, offset_x, offset_y);
     }
 
-    object_get_rect(obj, 0x7, &obj_rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &obj_rect);
     object_iso_invalidate_rect(&obj_rect);
 
     cur_sector_id = sector_id_from_loc(cur_loc);
@@ -2311,12 +2311,12 @@ void object_set_current_aid(int64_t obj, tig_art_id_t aid)
     TigRect update_rect;
 
     if ((obj_field_int32_get(obj, OBJ_F_FLAGS) & OF_DESTROYED) == 0) {
-        object_get_rect(obj, 0x7, &dirty_rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &dirty_rect);
         obj_field_int32_set(obj, OBJ_F_CURRENT_AID, aid);
         obj_field_int32_set(obj,
             OBJ_F_RENDER_FLAGS,
             obj_field_int32_get(obj, OBJ_F_RENDER_FLAGS) & ~ORF_08000000);
-        object_get_rect(obj, 0x7, &update_rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &update_rect);
         tig_rect_union(&dirty_rect, &update_rect, &dirty_rect);
         object_iso_invalidate_rect(&dirty_rect);
         sub_43F710(obj);
@@ -2356,7 +2356,7 @@ void object_overlay_set(int64_t obj, int fld, int index, tig_art_id_t aid)
         return;
     }
 
-    object_get_rect(obj, 0x7, &dirty_rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &dirty_rect);
     obj_arrayfield_uint32_set(obj, fld, index, aid);
 
     flags = obj_field_int32_get(obj, OBJ_F_FLAGS);
@@ -2391,7 +2391,7 @@ void object_overlay_set(int64_t obj, int fld, int index, tig_art_id_t aid)
         OBJ_F_RENDER_FLAGS,
         obj_field_int32_get(obj, OBJ_F_RENDER_FLAGS) & ~ORF_08000000);
 
-    object_get_rect(obj, 0x7, &updated_rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &updated_rect);
     tig_rect_union(&dirty_rect, &updated_rect, &dirty_rect);
     object_iso_invalidate_rect(&dirty_rect);
 }
@@ -2423,9 +2423,9 @@ void object_set_blit_scale(int64_t obj, int value)
     TigRect dirty_rect;
     TigRect update_rect;
 
-    object_get_rect(obj, 0x7, &dirty_rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &dirty_rect);
     obj_field_int32_set(obj, OBJ_F_BLIT_SCALE, value);
-    object_get_rect(obj, 0x7, &update_rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &update_rect);
     tig_rect_union(&dirty_rect, &update_rect, &dirty_rect);
     object_iso_invalidate_rect(&dirty_rect);
 }
@@ -2437,9 +2437,9 @@ void object_add_flags(int64_t obj, unsigned int flags)
     TigRect update_rect;
 
     if ((obj_field_int32_get(obj, OBJ_F_FLAGS) & OF_DESTROYED) == 0) {
-        object_get_rect(obj, 0x7, &dirty_rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &dirty_rect);
         object_flags_set(obj, flags);
-        object_get_rect(obj, 0x7, &update_rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &update_rect);
         tig_rect_union(&dirty_rect, &update_rect, &dirty_rect);
         object_iso_invalidate_rect(&dirty_rect);
         obj_field_int32_set(obj,
@@ -2455,9 +2455,9 @@ void object_remove_flags(int64_t obj, unsigned int flags)
     TigRect update_rect;
 
     if ((obj_field_int32_get(obj, OBJ_F_FLAGS) & OF_DESTROYED) == 0) {
-        object_get_rect(obj, 0x7, &dirty_rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &dirty_rect);
         object_flags_unset(obj, flags);
-        object_get_rect(obj, 0x7, &update_rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &update_rect);
         tig_rect_union(&dirty_rect, &update_rect, &dirty_rect);
         object_iso_invalidate_rect(&dirty_rect);
         obj_field_int32_set(obj,
@@ -2472,7 +2472,7 @@ void sub_43F030(int64_t obj)
     TigRect rect;
 
     if ((obj_field_int32_get(obj, OBJ_F_FLAGS) & OF_DESTROYED) == 0) {
-        object_get_rect(obj, 0x7, &rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &rect);
         object_iso_invalidate_rect(&rect);
         obj_field_int32_set(obj,
             OBJ_F_RENDER_FLAGS,
@@ -2493,7 +2493,7 @@ void object_cycle_palette(int64_t obj)
             aid = tig_art_id_palette_set(aid, 0);
         }
         obj_field_int32_set(obj, OBJ_F_CURRENT_AID, aid);
-        object_get_rect(obj, 0, &rect);
+        object_get_rect(obj, RECT_FLAG_NONE, &rect);
         object_iso_invalidate_rect(&rect);
         obj_field_int32_set(obj,
             OBJ_F_RENDER_FLAGS,
@@ -2513,7 +2513,7 @@ void sub_43F130(int64_t obj, int palette)
         // NOTE: Looks wrong.
         if (sub_502E00(aid) != TIG_OK) {
             obj_field_int32_set(obj, OBJ_F_CURRENT_AID, aid);
-            object_get_rect(obj, 0, &rect);
+            object_get_rect(obj, RECT_FLAG_NONE, &rect);
             object_iso_invalidate_rect(&rect);
             obj_field_int32_set(obj,
                 OBJ_F_RENDER_FLAGS,
@@ -2759,7 +2759,7 @@ void object_inc_current_aid(int64_t obj)
     TigRect update_rect;
 
     if ((obj_field_int32_get(obj, OBJ_F_FLAGS) & OF_DESTROYED) == 0) {
-        object_get_rect(obj, 0x7, &dirty_rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &dirty_rect);
         current_aid = obj_field_int32_get(obj, OBJ_F_CURRENT_AID);
         next_aid = tig_art_id_frame_inc(current_aid);
         if (current_aid != next_aid) {
@@ -2774,7 +2774,7 @@ void object_inc_current_aid(int64_t obj)
             obj_field_int32_set(obj,
                 OBJ_F_RENDER_FLAGS,
                 obj_field_int32_get(obj, OBJ_F_RENDER_FLAGS) & ~ORF_08000000);
-            object_get_rect(obj, 0x7, &update_rect);
+            object_get_rect(obj, RECT_FLAG_FULL, &update_rect);
             tig_rect_union(&dirty_rect, &update_rect, &dirty_rect);
             object_iso_invalidate_rect(&dirty_rect);
         }
@@ -2791,7 +2791,7 @@ void object_dec_current_aid(int64_t obj)
     TigRect update_rect;
 
     if ((obj_field_int32_get(obj, OBJ_F_FLAGS) & OF_DESTROYED) == 0) {
-        object_get_rect(obj, 0x7, &dirty_rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &dirty_rect);
         current_aid = obj_field_int32_get(obj, OBJ_F_CURRENT_AID);
         prev_aid = tig_art_id_frame_dec(current_aid);
         if (current_aid != prev_aid) {
@@ -2806,7 +2806,7 @@ void object_dec_current_aid(int64_t obj)
             obj_field_int32_set(obj,
                 OBJ_F_RENDER_FLAGS,
                 obj_field_int32_get(obj, OBJ_F_RENDER_FLAGS) & ~ORF_08000000);
-            object_get_rect(obj, 0x7, &update_rect);
+            object_get_rect(obj, RECT_FLAG_FULL, &update_rect);
             tig_rect_union(&dirty_rect, &update_rect, &dirty_rect);
             object_iso_invalidate_rect(&dirty_rect);
         }
@@ -2822,7 +2822,7 @@ void object_eye_candy_aid_inc(int64_t obj, int fld, int index)
     TigRect update_rect;
 
     if ((obj_field_int32_get(obj, OBJ_F_FLAGS) & OF_DESTROYED) == 0) {
-        object_get_rect(obj, 0x7, &dirty_rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &dirty_rect);
         current_aid = obj_arrayfield_uint32_get(obj, fld, index);
         next_aid = tig_art_id_frame_inc(current_aid);
         if (current_aid != next_aid) {
@@ -2830,7 +2830,7 @@ void object_eye_candy_aid_inc(int64_t obj, int fld, int index)
             obj_field_int32_set(obj,
                 OBJ_F_RENDER_FLAGS,
                 obj_field_int32_get(obj, OBJ_F_RENDER_FLAGS) & ~ORF_08000000);
-            object_get_rect(obj, 0x7, &update_rect);
+            object_get_rect(obj, RECT_FLAG_FULL, &update_rect);
             tig_rect_union(&dirty_rect, &update_rect, &dirty_rect);
             object_iso_invalidate_rect(&dirty_rect);
         }
@@ -2846,7 +2846,7 @@ void object_eye_candy_aid_dec(int64_t obj, int fld, int index)
     TigRect update_rect;
 
     if ((obj_field_int32_get(obj, OBJ_F_FLAGS) & OF_DESTROYED) == 0) {
-        object_get_rect(obj, 0x7, &dirty_rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &dirty_rect);
         current_aid = obj_arrayfield_uint32_get(obj, fld, index);
         prev_aid = tig_art_id_frame_get(current_aid) > 0
             ? tig_art_id_frame_dec(current_aid)
@@ -2856,7 +2856,7 @@ void object_eye_candy_aid_dec(int64_t obj, int fld, int index)
             obj_field_int32_set(obj,
                 OBJ_F_RENDER_FLAGS,
                 obj_field_int32_get(obj, OBJ_F_RENDER_FLAGS) & ~ORF_08000000);
-            object_get_rect(obj, 0x7, &update_rect);
+            object_get_rect(obj, RECT_FLAG_FULL, &update_rect);
             tig_rect_union(&dirty_rect, &update_rect, &dirty_rect);
             object_iso_invalidate_rect(&dirty_rect);
         }
@@ -2934,7 +2934,7 @@ void object_cycle_rotation(int64_t obj)
     TigRect dirty_rect;
 
     if ((obj_field_int32_get(obj, OBJ_F_FLAGS) & OF_DESTROYED) == 0) {
-        object_get_rect(obj, 0x7, &dirty_rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &dirty_rect);
         current_aid = obj_field_int32_get(obj, OBJ_F_CURRENT_AID);
         next_aid = tig_art_id_rotation_inc(current_aid);
         if (current_aid != next_aid) {
@@ -3844,7 +3844,7 @@ void object_drop(int64_t obj, int64_t loc)
     obj_field_int32_set(obj, OBJ_F_RENDER_FLAGS, 0);
     sub_4D9590(obj, true);
     sub_444270(obj, 2);
-    object_get_rect(obj, 0x07, &rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &rect);
     object_iso_invalidate_rect(&rect);
 }
 
@@ -3908,7 +3908,7 @@ void object_pickup(int64_t item_obj, int64_t parent_obj)
 
     sub_4D9990(item_obj);
     sub_4D9A90(item_obj);
-    object_get_rect(item_obj, 0x07, &rect);
+    object_get_rect(item_obj, RECT_FLAG_FULL, &rect);
     loc = obj_field_int64_get(item_obj, OBJ_F_LOCATION);
     sec = sector_id_from_loc(loc);
     if (sub_4D04E0(sec)) {
@@ -4304,7 +4304,7 @@ bool object_duplicate_func(int64_t proto_obj, int64_t loc, ObjectID* oids, int64
         return false;
     }
 
-    sub_43E770(*obj_ptr, loc, 0, 0);
+    object_move_to_location(*obj_ptr, loc, 0, 0);
 
     if (obj_field_int32_get(*obj_ptr, OBJ_F_TYPE) == OBJ_TYPE_NPC) {
         obj_field_int64_set(*obj_ptr, OBJ_F_NPC_STANDPOINT_DAY, loc);
@@ -4372,7 +4372,7 @@ bool sub_442260(int64_t obj, int64_t loc)
     sub_463C60(obj);
     sub_444270(obj, 2);
 
-    object_get_rect(obj, 0x7, &rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &rect);
     object_iso_invalidate_rect(&rect);
 
     return true;
@@ -4387,7 +4387,7 @@ void sub_4423E0(int64_t obj, int offset_x, int offset_y)
     int64_t sector_id;
     Sector* sector;
 
-    object_get_rect(obj, 0x7, &rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &rect);
     loc = obj_field_int64_get(obj, OBJ_F_LOCATION);
     flags = obj_field_int32_get(obj, OBJ_F_FLAGS);
 
@@ -4502,7 +4502,7 @@ void sub_442520(int64_t obj)
             new_render_flags |= ORF_20000000;
         } else if (cnt == 2) {
             new_render_flags |= ORF_40000000;
-            object_get_rect(obj, 0, &obj_rect);
+            object_get_rect(obj, RECT_FLAG_NONE, &obj_rect);
             color = colors.colors[obj_rect.width / 2];
         } else {
             color = colors.colors[0];
@@ -4532,7 +4532,7 @@ void sub_442520(int64_t obj)
         sub_442D90(obj, &colors);
     }
 
-    object_get_rect(obj, 0x07, &obj_rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &obj_rect);
     object_iso_invalidate_rect(&obj_rect);
 }
 
@@ -4731,7 +4731,7 @@ void object_toggle_flat(int64_t obj, bool flat)
     Sector* sector;
     unsigned int flags;
 
-    object_get_rect(obj, 0x7, &rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &rect);
     sector_id = sector_id_from_loc(obj_field_int64_get(obj, OBJ_F_LOCATION));
 
     flags = obj_field_int32_get(obj, OBJ_F_FLAGS);
@@ -4983,7 +4983,7 @@ bool sub_4437E0(TigRect* rect)
     }
 
     if (!dword_5E2E94) {
-        object_get_rect(object_hover_obj, 0, rect);
+        object_get_rect(object_hover_obj, RECT_FLAG_NONE, rect);
         return true;
     }
 
@@ -5299,7 +5299,7 @@ void sub_444270(int64_t obj, int a2)
             obj_field_int32_set(obj, OBJ_F_RENDER_FLAGS, render_flags);
         }
 
-        object_get_rect(obj, 0x7, &rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &rect);
         object_iso_invalidate_rect(&rect);
         return;
     }
@@ -5321,7 +5321,7 @@ void sub_444270(int64_t obj, int a2)
     if (object_editor) {
         obj_field_int32_set(obj, OBJ_F_RENDER_FLAGS, render_flags);
         obj_field_int32_set(obj, OBJ_F_FLAGS, flags);
-        object_get_rect(obj, 0x7, &rect);
+        object_get_rect(obj, RECT_FLAG_FULL, &rect);
         object_iso_invalidate_rect(&rect);
         return;
     }
@@ -5356,7 +5356,7 @@ void sub_444270(int64_t obj, int a2)
     }
 
     obj_field_int32_set(obj, OBJ_F_RENDER_FLAGS, render_flags);
-    object_get_rect(obj, 0x7, &rect);
+    object_get_rect(obj, RECT_FLAG_FULL, &rect);
     object_iso_invalidate_rect(&rect);
 }
 
@@ -5407,7 +5407,7 @@ void sub_4445A0(int64_t a1, int64_t a2)
                 }
             } else {
                 loc = obj_field_int64_get(a1, OBJ_F_LOCATION);
-                sub_43E770(a2, loc, 0, 0);
+                object_move_to_location(a2, loc, 0, 0);
             }
         }
     }

--- a/src/game/object.h
+++ b/src/game/object.h
@@ -50,6 +50,14 @@
     | OBJ_TM_NPC                \
     | OBJ_TM_TRAP)
 
+#define RECT_FLAG_NONE 0x00000000
+#define RECT_FLAG_SHADOWS 0x00000001
+#define RECT_FLAG_OVERLAYS 0x00000002
+#define RECT_FLAG_UNDERLAYS 0x00000004
+#define RECT_FLAG_IGNORE_VIS 0x00000008
+#define RECT_FLAG_ALL_LAYERS (RECT_FLAG_OVERLAYS | RECT_FLAG_UNDERLAYS)
+#define RECT_FLAG_FULL (RECT_FLAG_SHADOWS | RECT_FLAG_OVERLAYS | RECT_FLAG_UNDERLAYS)
+
 // TODO: Better name.
 typedef struct Ryan {
     /* 0000 */ ObjectID objid;
@@ -123,7 +131,7 @@ bool sub_43D940(int64_t obj);
 bool object_is_static(int64_t obj);
 bool sub_43D9F0(int x, int y, int64_t* obj_ptr, unsigned int flags);
 void object_get_rect(int64_t obj, unsigned int flags, TigRect* rect);
-void sub_43E770(int64_t obj, int64_t loc, int offset_x, int offset_y);
+void object_move_to_location(int64_t obj, int64_t loc, int offset_x, int offset_y);
 bool object_teleported_timeevent_process(TimeEvent* timeevent);
 void object_set_offset(int64_t obj, int offset_x, int offset_y);
 void object_set_current_aid(int64_t obj, tig_art_id_t aid);

--- a/src/game/wallcheck.c
+++ b/src/game/wallcheck.c
@@ -1062,7 +1062,7 @@ void sub_438830()
                 render_flags &= ~ORF_01000000;
                 obj_field_int32_set(stru_5E0E20[idx].obj, OBJ_F_RENDER_FLAGS, render_flags);
 
-                object_get_rect(stru_5E0E20[idx].obj, 0, &obj_rect);
+                object_get_rect(stru_5E0E20[idx].obj, RECT_FLAG_NONE, &obj_rect);
                 dword_5E0A00(&obj_rect);
             }
 
@@ -1095,7 +1095,7 @@ void sub_438830()
                     render_flags &= ~ORF_01000000;
                     obj_field_int32_set(stru_5E0E20[idx].obj, OBJ_F_RENDER_FLAGS, render_flags);
 
-                    object_get_rect(stru_5E0E20[idx].obj, 0, &obj_rect);
+                    object_get_rect(stru_5E0E20[idx].obj, RECT_FLAG_NONE, &obj_rect);
                     dword_5E0A00(&obj_rect);
                 }
             }

--- a/src/main.c
+++ b/src/main.c
@@ -173,7 +173,7 @@ int main(int argc, char** argv)
     }
 
     // NOTE: The `geometry` switch is also borrowed from ToEE, but the
-    // implementation is different (original implementaion is wrong).
+    // implementation is different (original implementation is wrong).
     pch = strstr(lpCmdLine, "-geometry");
     if (pch != NULL) {
         int width;
@@ -333,7 +333,7 @@ void main_loop()
 
     pc_obj = player_get_local_pc_obj();
     location = obj_field_int64_get(pc_obj, OBJ_F_LOCATION);
-    sub_43E770(pc_obj, location, 0, 0);
+    object_move_to_location(pc_obj, location, 0, 0);
     location_origin_set(location);
 
     art_id = obj_field_int32_get(pc_obj, OBJ_F_CURRENT_AID);

--- a/src/ui/wmap_rnd.c
+++ b/src/ui/wmap_rnd.c
@@ -947,7 +947,7 @@ void sub_559260(WmapRndEncounterTableEntry* entry)
                     object_destroy(obj);
                     obj = OBJ_HANDLE_NULL;
                 } else {
-                    sub_43E770(obj, loc, 0, 0);
+                    object_move_to_location(obj, loc, 0, 0);
                 }
             }
 


### PR DESCRIPTION
Add definitions for RECT_FLAG for func object_get_rect. 
Add array initialization in func sub_43D9F0. Fixed using uninitialized value.