### PR TITLE
fix(hotkey_ui): use item inventory art up to 32x32 pixels inclusive

### DIFF
--- a/src/ui/hotkey_ui.c
+++ b/src/ui/hotkey_ui.c
@@ -551,8 +551,8 @@ void intgame_hotkey_refresh(int index)
         if (hotkey->type == HOTKEY_ITEM) {
             inv_art_id = obj_field_int32_get(hotkey->item_obj.obj, OBJ_F_ITEM_INV_AID);
             if (tig_art_frame_data(inv_art_id, &art_frame_data) == TIG_OK
-                && art_frame_data.width < 32
-                && art_frame_data.height < 32) {
+                && art_frame_data.width <= 32
+                && art_frame_data.height <= 32) {
                 art_id = inv_art_id;
             }
         }


### PR DESCRIPTION
Trivial fix that restores hotkey panel ability to show item's inventory art as is, for up to 32x32 (inclusive) - instead of generic item art placeholders that are shown for many one-cell items currently:

before fix:
<img width="1340" height="164" alt="image" src="https://github.com/user-attachments/assets/161a373f-c410-413e-ba4f-4772ef6ff81f" />

after fix:
<img width="1330" height="156" alt="image" src="https://github.com/user-attachments/assets/9b2e309c-a0cc-497b-b97b-aa56f62bb6d2" />
