### PR TITLE
fix(scrollbar_ui): scroll-up drag loop runs away instead of converging

### DIFF
--- a/src/ui/scrollbar_ui.c
+++ b/src/ui/scrollbar_ui.c
@@ -653,7 +653,7 @@ bool scrollbar_ui_process_event(TigMessage* msg)
                 } else if (remainder < -thumb_height && ctrl->info.value + scrollbar_ui_drag_delta > ctrl->info.min_value) {
                     // Accumulate whole `line_step` decrements when moving up.
                     do {
-                        remainder += -thumb_height;
+                        remainder += thumb_height;
                         scrollbar_ui_drag_delta -= ctrl->info.line_step;
                     } while (remainder < -thumb_height && ctrl->info.value + scrollbar_ui_drag_delta > ctrl->info.min_value);
                 } else {


### PR DESCRIPTION
A trivial fix for the scrollbar_ui drag-up routine: adding a negative value made remainder diverge further negative instead of converging toward zero.

The issue is seen on any non-empty container, when dragging the scroll bar up (a junk pile, a chest, even at the character creation shop UI): 

https://github.com/user-attachments/assets/9238fa85-9e12-45f9-a961-dbe2d92c888f

When fixed, can drag up smoothly again:

https://github.com/user-attachments/assets/ac6520c2-7056-4dbb-a410-83dbde441ef3

