### PR TITLE
Fixes for grenade objects

### DIFF
--- a/src/game/anim.c
+++ b/src/game/anim.c
@@ -151,7 +151,7 @@ static bool AGapplyFireDmg(AnimRunInfo* run_info);
 static bool sub_42A930(AnimRunInfo* run_info);
 static bool sub_42A9B0(AnimRunInfo* run_info);
 static bool sub_42AA70(int64_t source_obj, int64_t target_obj);
-static bool sub_42AB90(AnimRunInfo* run_info);
+static bool combat_throw_start(AnimRunInfo* run_info);
 static bool sub_42ACD0(AnimRunInfo* run_info);
 static bool sub_42AE10(AnimRunInfo* run_info);
 static bool sub_42AF00(AnimRunInfo* run_info);
@@ -1224,7 +1224,7 @@ static AnimGoalNode anim_goal_node_throw_item = {
         /*  4 */ { sub_42C390, { AGDATA_SELF_OBJ, AGDATA_TARGET_TILE }, -1, 8, 0, 5, 0 },
         /*  5 */ { sub_42CB10, { AGDATA_SELF_OBJ, AGDATA_ANIM_ID }, -1, 8, 0, 0x10000000, 0 },
         /*  6 */ { sub_42CAA0, { AGDATA_SELF_OBJ, AGDATA_ANIM_ID }, -1, 0x10000000, -2, 7, 0 },
-        /*  7 */ { sub_42AB90, { AGDATA_SELF_OBJ, AGDATA_SCRATCH_OBJ }, 5, 8, 0, 0x10000000, -2 },
+        /*  7 */ { combat_throw_start, { AGDATA_SELF_OBJ, AGDATA_SCRATCH_OBJ }, 5, 8, 0, 0x10000000, -2 },
         /*  8 */ { sub_42BD40, { AGDATA_SELF_OBJ, -1 }, 0, 9, 0, 9, 0 },
         /*  9 */ { sub_433270, { AGDATA_SELF_OBJ, -1 }, 1, 0x90000000, 0, 0x90000000, 0 },
         /* 10 */ { 0 },
@@ -3688,7 +3688,7 @@ bool anim_timeevent_process(TimeEvent* timeevent)
 
         state_change = rc ? goal_subnode->field_18 : goal_subnode->field_10;
         delay = rc ? goal_subnode->field_1C : goal_subnode->field_14;
-
+        
         if ((state_change & 0xFF000000) != 0) {
             if ((state_change & 0x10000000) != 0) {
                 run_info->current_state = 0;
@@ -7749,7 +7749,7 @@ bool AGapplyFireDmg(AnimRunInfo* run_info)
     object_list_location(source_loc, OBJ_TM_CRITTER | OBJ_TM_ITEM, &objects);
     node = objects.head;
     while (node != NULL) {
-        sub_4B2210(source_obj, node->obj, &combat);
+        combat_context_setup(source_obj, OBJ_HANDLE_NULL, node->obj, &combat);
         combat.field_30 = parent_obj;
         if ((run_info->cur_stack_data->params[AGDATA_FLAGS_DATA].data & 0x4000) != 0) {
             dam = 1;
@@ -7896,7 +7896,7 @@ bool sub_42AA70(int64_t source_obj, int64_t target_obj)
 }
 
 // 0x42AB90
-bool sub_42AB90(AnimRunInfo* run_info)
+bool combat_throw_start(AnimRunInfo* run_info)
 {
     int64_t source_obj;
     int64_t item_obj;
@@ -7930,6 +7930,8 @@ bool sub_42AB90(AnimRunInfo* run_info)
     }
 
     combat_throw(source_obj, item_obj, target_obj, target_loc, HIT_LOC_TORSO);
+
+    combat_consume_action_points(source_obj, 4);
 
     run_info->cur_stack_data->params[AGDATA_SCRATCH_OBJ].obj = OBJ_HANDLE_NULL;
 
@@ -10993,7 +10995,7 @@ bool AGupdateAnimMoveStraightKnockback(AnimRunInfo* run_info)
         if (new_loc != loc) {
             if (sub_42FD70(run_info, obj, &(run_info->path), loc, new_loc)) {
                 sub_43E770(obj, loc, 0, 0);
-                sub_4B2210(OBJ_HANDLE_NULL, obj, &combat);
+                combat_context_setup(OBJ_HANDLE_NULL, OBJ_HANDLE_NULL, obj, &combat);
                 combat.dam[DAMAGE_TYPE_NORMAL] = random_between(1, (run_info->path.max - run_info->path.curr) / 2);
                 combat.dam[DAMAGE_TYPE_FATIGUE] = random_between(1, (run_info->path.max - run_info->path.curr) / 2);
                 combat.field_30 = run_info->cur_stack_data->params[AGDATA_SCRATCH_OBJ].obj;

--- a/src/game/combat.c
+++ b/src/game/combat.c
@@ -356,14 +356,19 @@ bool combat_load(GameLoadInfo* load_info)
 }
 
 // 0x4B2210
-void sub_4B2210(int64_t attacker_obj, int64_t target_obj, CombatContext* combat)
+void combat_context_setup(int64_t attacker_obj, int64_t weapon_obj, int64_t target_obj, CombatContext* combat)
 {
     int type;
 
     combat->flags = 0;
     combat->attacker_obj = attacker_obj;
 
-    if (attacker_obj != OBJ_HANDLE_NULL) {
+    if (weapon_obj != OBJ_HANDLE_NULL)
+    {
+        type = obj_field_int32_get(attacker_obj, OBJ_F_TYPE);
+        combat->weapon_obj = weapon_obj;
+    }
+    else if (attacker_obj != OBJ_HANDLE_NULL) {
         type = obj_field_int32_get(attacker_obj, OBJ_F_TYPE);
         if (obj_type_is_critter(type)) {
             combat->weapon_obj = combat_critter_weapon(attacker_obj);
@@ -694,7 +699,7 @@ bool sub_4B2870(int64_t attacker_obj, int64_t target_obj, int64_t target_loc, in
     if (block_obj != OBJ_HANDLE_NULL) {
         CombatContext combat;
 
-        sub_4B2210(attacker_obj, block_obj, &combat);
+        combat_context_setup(attacker_obj, OBJ_HANDLE_NULL, block_obj, &combat);
 
         if (target_obj != OBJ_HANDLE_NULL) {
             combat.field_28 = target_obj;
@@ -1048,7 +1053,7 @@ void combat_process_melee_attack(CombatContext* combat)
 
         if ((obj_field_int32_get(combat->attacker_obj, OBJ_F_SPELL_FLAGS) & OSF_BODY_OF_FIRE) == 0
             && (obj_field_int32_get(combat->target_obj, OBJ_F_SPELL_FLAGS) & OSF_BODY_OF_FIRE) != 0) {
-            sub_4B2210(combat->target_obj, combat->attacker_obj, &body_of_fire);
+            combat_context_setup(combat->target_obj, OBJ_HANDLE_NULL, combat->attacker_obj, &body_of_fire);
             body_of_fire.dam[DAMAGE_TYPE_FIRE] = 5;
             combat_dmg(&body_of_fire);
         }
@@ -1139,7 +1144,7 @@ void sub_4B3BB0(int64_t attacker_obj, int64_t target_obj, int hit_loc)
 {
     CombatContext combat;
 
-    sub_4B2210(attacker_obj, target_obj, &combat);
+    combat_context_setup(attacker_obj, OBJ_HANDLE_NULL, target_obj, &combat);
     combat.hit_loc = hit_loc;
     combat.flags |= CF_WEAPON_WEAR;
     combat.flags |= 0x40000;
@@ -1158,7 +1163,7 @@ void combat_throw(int64_t attacker_obj, int64_t weapon_obj, int64_t target_obj, 
     }
 
     if (object_script_execute(attacker_obj, weapon_obj, target_obj, SAP_THROW, 0)) {
-        sub_4B2210(attacker_obj, target_obj, &combat);
+        combat_context_setup(attacker_obj, weapon_obj, target_obj, &combat);
         combat.hit_loc = hit_loc;
         combat.weapon_obj = weapon_obj;
         if (target_obj == OBJ_HANDLE_NULL) {
@@ -2428,7 +2433,7 @@ void combat_process_crit_hit(CombatContext* combat)
     int attacker_obj_type;
     bool npc_attacks_pc;
     CritHitType crit_hit_type;
-    int chance;
+    int chance =0;
     CritBodyType crit_body_type;
     unsigned int critter_flags;
     int64_t helmet_obj;
@@ -3675,7 +3680,7 @@ bool combat_consume_action_points(int64_t obj, int action_points)
     if (combat_action_points > 0
         && is_pc
         && critter_fatigue_current(obj) > 1) {
-        sub_4B2210(OBJ_HANDLE_NULL, obj, &combat);
+        combat_context_setup(OBJ_HANDLE_NULL, OBJ_HANDLE_NULL, obj, &combat);
         combat.flags |= 0x80;
         combat.dam[DAMAGE_TYPE_FATIGUE] = 2;
         combat_dmg(&combat);

--- a/src/game/combat.h
+++ b/src/game/combat.h
@@ -98,7 +98,7 @@ void combat_exit(void);
 void combat_reset(void);
 bool combat_save(TigFile* stream);
 bool combat_load(GameLoadInfo* load_info);
-void sub_4B2210(int64_t attacker_obj, int64_t target_obj, CombatContext* combat);
+void combat_context_setup(int64_t attacker_obj, int64_t weapon_obj, int64_t target_obj, CombatContext* combat);
 int64_t combat_critter_weapon(int64_t critter_obj);
 void sub_4B2650(int64_t a1, int64_t a2, CombatContext* combat);
 bool sub_4B2870(int64_t attacker_obj, int64_t target_obj, int64_t target_loc, int64_t projectile_obj, int range, int64_t cur_loc, int64_t a7);

--- a/src/game/critter.c
+++ b/src/game/critter.c
@@ -627,7 +627,7 @@ void critter_kill(int64_t obj)
         return;
     }
 
-    sub_4B2210(OBJ_HANDLE_NULL, obj, &combat);
+    combat_context_setup(OBJ_HANDLE_NULL, OBJ_HANDLE_NULL, obj, &combat);
     combat.dam_flags |= CDF_DEATH;
     combat_dmg(&combat);
 
@@ -826,6 +826,11 @@ void sub_45DC90(int64_t killer_obj, int64_t victim_obj, bool a3)
 int64_t critter_pc_leader_get(int64_t obj)
 {
     int64_t leader_obj = obj;
+
+    //Return self if PC
+    if (obj_field_int32_get(obj, OBJ_F_TYPE) == OBJ_TYPE_PC) {
+        return obj;
+    }
 
     // Only NPCs have leaders.
     if (obj_field_int32_get(obj, OBJ_F_TYPE) != OBJ_TYPE_NPC) {

--- a/src/game/magictech.c
+++ b/src/game/magictech.c
@@ -2227,7 +2227,7 @@ void MTComponentDamage_ProcFunc(void)
         return;
     }
 
-    sub_4B2210(magictech_cur_run_info->parent_obj.obj, stru_5E6D28.target_obj, &combat);
+    combat_context_setup(magictech_cur_run_info->parent_obj.obj, OBJ_HANDLE_NULL, stru_5E6D28.target_obj, &combat);
 
     combat.dam_flags |= magictech_cur_component->data.damage.damage_flags;
 
@@ -2304,7 +2304,7 @@ void MTComponentDestroy_ProcFunc(void)
     }
 
     spell_flags = obj_field_int32_get(stru_5E6D28.target_obj, OBJ_F_SPELL_FLAGS);
-    if (!magictech_cur_run_info->field_144 || (spell_flags & OSF_SUMMONED) != 0) {
+    if ((!magictech_cur_run_info->field_144 && !obj_type_is_critter(magictech_cur_target_obj_type)) || (spell_flags & OSF_SUMMONED) != 0) {
         object_destroy(stru_5E6D28.target_obj);
 
         if (tig_net_is_active()
@@ -2559,7 +2559,7 @@ void MTComponentHeal_ProcFunc(void)
     int heal_max;
 
     if (stru_5E6D28.target_obj != OBJ_HANDLE_NULL) {
-        sub_4B2210(magictech_cur_run_info->parent_obj.obj, stru_5E6D28.target_obj, &combat);
+        combat_context_setup(magictech_cur_run_info->parent_obj.obj, OBJ_HANDLE_NULL, stru_5E6D28.target_obj, &combat);
         combat.dam_flags |= magictech_cur_component->data.heal.damage_flags;
         if ((combat.dam_flags & CDF_FULL) == 0) {
             heal_min = magictech_cur_component->data.heal.damage_min;
@@ -4148,7 +4148,7 @@ void magictech_component_obj_flag(int64_t obj, int64_t a2, int fld, int a4, int 
             } else if ((a4 & OSF_WATER_WALKING) != 0) {
                 object_flags_unset(obj, OF_WATER_WALKING);
                 if (tile_is_blocking(obj_field_int64_get(obj, OBJ_F_LOCATION), false)) {
-                    sub_4B2210(OBJ_HANDLE_NULL, obj, &combat);
+                    combat_context_setup(OBJ_HANDLE_NULL, OBJ_HANDLE_NULL, obj, &combat);
                     combat.dam_flags |= CDF_FULL;
                     combat_dmg(&combat);
 

--- a/src/game/script.c
+++ b/src/game/script.c
@@ -2065,7 +2065,7 @@ int script_execute_action(ScriptAction* action, int line, ScriptState* state)
         int damage = script_get_value(action->op_type[1], action->op_value[1], state);
         int type = script_get_value(action->op_type[2], action->op_value[2], state);
         for (int idx = 0; idx < cnt; idx++) {
-            sub_4B2210(OBJ_HANDLE_NULL, handles[idx], &combat);
+            combat_context_setup(OBJ_HANDLE_NULL, OBJ_HANDLE_NULL, handles[idx], &combat);
             combat.dam[type] = damage;
             combat_dmg(&combat);
         }
@@ -2180,7 +2180,7 @@ int script_execute_action(ScriptAction* action, int line, ScriptState* state)
         int cnt = script_resolve_focus_obj(action->op_type[0], action->op_value[0], state, handles, &objects);
         int value = script_get_value(action->op_type[1], action->op_value[1], state);
         for (int idx = 0; idx < cnt; idx++) {
-            sub_4B2210(OBJ_HANDLE_NULL, handles[idx], &combat);
+            combat_context_setup(OBJ_HANDLE_NULL, OBJ_HANDLE_NULL, handles[idx], &combat);
             combat.dam[DAMAGE_TYPE_NORMAL] = value;
             combat_heal(&combat);
         }
@@ -2778,7 +2778,7 @@ int script_execute_action(ScriptAction* action, int line, ScriptState* state)
         int damage = script_get_value(action->op_type[1], action->op_value[1], state);
         int type = script_get_value(action->op_type[2], action->op_value[2], state);
         for (int idx = 0; idx < cnt; idx++) {
-            sub_4B2210(OBJ_HANDLE_NULL, handles[idx], &combat);
+            combat_context_setup(OBJ_HANDLE_NULL, OBJ_HANDLE_NULL, handles[idx], &combat);
             combat.dam[type] = damage;
             combat.dam_flags |= CDF_IGNORE_RESISTANCE;
             combat_dmg(&combat);

--- a/src/game/skill.c
+++ b/src/game/skill.c
@@ -1791,7 +1791,7 @@ bool skill_invocation_run(SkillInvocation* skill_invocation)
         CombatContext combat;
 
         // Initialize combat invocation for healing.
-        sub_4B2210(source_obj, target_obj, &combat);
+        combat_context_setup(source_obj, OBJ_HANDLE_NULL, target_obj, &combat);
 
         if (is_success) {
             int heal;

--- a/src/game/stat.c
+++ b/src/game/stat.c
@@ -1022,7 +1022,7 @@ bool stat_poison_timeevent_process(TimeEvent* timeevent)
     case POISON_EVENT_DAMAGE:
         if (poison > 0) {
             if ((obj_field_int32_get(obj, OBJ_F_FLAGS) & OF_OFF) == 0) {
-                sub_4B2210(OBJ_HANDLE_NULL, obj, &combat);
+                combat_context_setup(OBJ_HANDLE_NULL, OBJ_HANDLE_NULL, obj, &combat);
 
                 // Determine damage based on poison severity.
                 if (poison >= 550) {

--- a/src/game/trap.c
+++ b/src/game/trap.c
@@ -755,7 +755,7 @@ void trigger_trap(int64_t obj, ScriptInvocation* invocation)
         magictech_invocation_run(&mt_invocation);
         return;
     case TRAP_SCRIPT_MECHANICAL:
-        sub_4B2210(invocation->attachee_obj, obj, &combat);
+        combat_context_setup(invocation->attachee_obj, OBJ_HANDLE_NULL, obj, &combat);
         combat.field_30 = sub_4BD950(invocation->attachee_obj);
         combat.flags |= CF_TRAP;
         combat.flags |= 0x300;
@@ -765,7 +765,7 @@ void trigger_trap(int64_t obj, ScriptInvocation* invocation)
     case TRAP_SCRIPT_ARROW:
         trap_source_obj = find_trap_source(invocation->attachee_obj, (invocation->script->hdr.counters >> 16) & 0xFF);
         if (trap_source_obj != OBJ_HANDLE_NULL) {
-            sub_4B2210(trap_source_obj, obj, &combat);
+            combat_context_setup(trap_source_obj, OBJ_HANDLE_NULL, obj, &combat);
             combat.field_30 = sub_4BD950(invocation->attachee_obj);
             combat.flags |= 0x300;
             combat.weapon_obj = OBJ_HANDLE_NULL;
@@ -774,7 +774,7 @@ void trigger_trap(int64_t obj, ScriptInvocation* invocation)
         }
         break;
     case TRAP_SCRIPT_BULLET:
-        sub_4B2210(invocation->attachee_obj, obj, &combat);
+        combat_context_setup(invocation->attachee_obj, OBJ_HANDLE_NULL, obj, &combat);
         combat.field_30 = sub_4BD950(invocation->attachee_obj);
         combat.flags |= CF_TRAP;
         combat.flags |= 0x300;
@@ -782,7 +782,7 @@ void trigger_trap(int64_t obj, ScriptInvocation* invocation)
         combat_dmg(&combat);
         break;
     case TRAP_SCRIPT_FIRE:
-        sub_4B2210(invocation->attachee_obj, obj, &combat);
+        combat_context_setup(invocation->attachee_obj, OBJ_HANDLE_NULL, obj, &combat);
         combat.field_30 = sub_4BD950(invocation->attachee_obj);
         combat.flags |= CF_TRAP;
         combat.flags |= 0x300;
@@ -790,7 +790,7 @@ void trigger_trap(int64_t obj, ScriptInvocation* invocation)
         combat_dmg(&combat);
         break;
     case TRAP_SCRIPT_ELECTRICAL:
-        sub_4B2210(invocation->attachee_obj, obj, &combat);
+        combat_context_setup(invocation->attachee_obj, OBJ_HANDLE_NULL, obj, &combat);
         combat.field_30 = sub_4BD950(invocation->attachee_obj);
         combat.flags |= CF_TRAP;
         combat.flags |= 0x300;
@@ -798,7 +798,7 @@ void trigger_trap(int64_t obj, ScriptInvocation* invocation)
         combat_dmg(&combat);
         break;
     case TRAP_SCRIPT_POISON:
-        sub_4B2210(invocation->attachee_obj, obj, &combat);
+        combat_context_setup(invocation->attachee_obj, OBJ_HANDLE_NULL, obj, &combat);
         combat.field_30 = sub_4BD950(invocation->attachee_obj);
         combat.flags |= CF_TRAP;
         combat.flags |= 0x300;


### PR DESCRIPTION
Issues:
Grenade objects are not being passed into CombatContext object, resulting in the character's weapon being used instead
critter_pc_leader_get doesn't return with the PC when the PC is passed in (resulting in grenades thrown by the PC targeting themselves)
MTComponentDestroy_ProcFunc is deleting anything hit by a grenade