### PR TITLE
fix(target): use `spell_flags` instead of `flags` for summoned-object…

### DIFF
--- a/src/game/target.c
+++ b/src/game/target.c
@@ -903,7 +903,7 @@ bool target_context_evaluate(TargetContext* ctx)
             }
 
             if ((tgt & 0x400000000000) != 0
-                && (flags & OSF_SUMMONED) == 0) {
+                && (spell_flags & OSF_SUMMONED) == 0) {
                 return false;
             }
 


### PR DESCRIPTION
Fixes #117


https://github.com/user-attachments/assets/548a5a18-c09a-439f-9d95-7f4835a706bb


There are many workaround-like fixes possible, but I specifically wanted to figure out where the CE diverges from the OG to fix the regression, and I believe that is the exact piece of code.

<details><summary>Full details. The debugging and the report was AI assisted</summary>


## FIX: Bodies disappear after dynamite explosion kills


Status: Root cause identified and fixed


### 1. SUMMARY

When a critter is killed by a dynamite explosion, the death animation plays but
the body disappears afterward. The root cause is a wrong variable in
target_context_evaluate() - the CE checks OBJ_F_FLAGS instead of
OBJ_F_SPELL_FLAGS when evaluating the Tgt_Summoned_No_Obj targeting flag.

Fix: src/game/target.c line 906 - change `flags` to `spell_flags`.


### 2. ROOT CAUSE

In target_context_evaluate() (src/game/target.c:905-908, OG address 0x4F2D20),
there is a check for the Tgt_Summoned_No_Obj flag (0x400000000000):

CE code (BEFORE fix):
```c
flags = obj_field_int32_get(ctx->target_obj, OBJ_F_FLAGS);         // line 484
//...
spell_flags = obj_field_int32_get(ctx->target_obj, OBJ_F_SPELL_FLAGS); // line 510
//...
if ((tgt & 0x400000000000) != 0
  && (flags & OSF_SUMMONED) == 0) {       // <-- BUG: reads OBJ_F_FLAGS
  return false;
}
```

CE code (AFTER fix):
```c
if ((tgt & 0x400000000000) != 0
  && (spell_flags & OSF_SUMMONED) == 0) {  // <-- FIXED: reads OBJ_F_SPELL_FLAGS
    return false;
}
```

The bug exists because OSF_SUMMONED (a spell flag) and OF_PROVIDES_COVER (an
object flag) share the same bit value 0x4000 but belong to different fields:

src/game/obj_flags.h:
```c
#define OF_PROVIDES_COVER   0x00004000u    // OBJ_F_FLAGS field
#define OSF_SUMMONED        0x00004000u    // OBJ_F_SPELL_FLAGS field
```

When the CE checks `flags & OSF_SUMMONED`, it is actually testing
`OBJ_F_FLAGS & 0x4000`, which equals OF_PROVIDES_COVER. A critter with
OF_PROVIDES_COVER set passes the check (incorrectly treated as "summoned"),
allowing it into the target list. A critter without OF_PROVIDES_COVER is
correctly rejected - but for the wrong reason.

The net effect: critters with OF_PROVIDES_COVER leak into target lists that
should only contain summoned objects. For the dynamite spell's callback Destroy
component, this means the dead critter ends up targeted for destruction.


### 3. OG BINARY VERIFICATION

The OG binary (Arcanum.exe) correctly reads OBJ_F_SPELL_FLAGS.

OG disassembly of target_context_evaluate at the Tgt_Summoned_No_Obj check:

Address: 0x4F3A6E - 0x4F3A95
```asm
    4f3a6e:  mov    ebp, DWORD PTR [esp+0x1c]     ; ebp = tgt_hi
    4f3a74:  mov    ecx, ebp
    4f3a76:  and    ecx, 0x4000                    ; test Tgt_Summoned_No_Obj
    4f3a7c:  or     eax, ecx
    4f3a7e:  je     0x4f3a96                       ; skip if flag not set
    4f3a80:  mov    eax, DWORD PTR [esp+0x14]      ; eax = spell_flags
    4f3a84:  test   ah, 0x40                       ; test bit 14 = 0x4000 = OSF_SUMMONED
    4f3a87:  jne    0x4f3a96                       ; if summoned, allow through
    4f3a89:  ...                                   ; return false (not summoned)
```

The value at [esp+0x14] is spell_flags, set earlier in the function:

```asm
    4f2df3:  push   0x14                           ; OBJ_F_SPELL_FLAGS = 0x14
    4f2df5:  push   eax                            ; obj handle (high)
    4f2df6:  push   ecx                            ; obj handle (low)
    4f2df7:  call   0x406ca0                       ; obj_field_int32_get
    4f2e03:  mov    DWORD PTR [esp+0x14], edx      ; store spell_flags
```

The Arcanum CE reads `flags` (from OBJ_F_FLAGS at line 484) instead of `spell_flags`
(from OBJ_F_SPELL_FLAGS at line 510). The OG reads the correct field.


### 4. HOW THE BUG CAUSES BODY DISAPPEARANCE

The dynamite spell (spell 176, spelllist.mes entry 11800) has two actions:

  BEGIN (action 0, 8 components):
    - Damage (fire + normal) - kills the critter
    - EyeCandy (with ANIMFX_PLAY_CALLBACK flag) - schedules deferred callback
    - Summon (Proto 4050) - creates explosion debris
    - Destroy - targets nothing useful during BEGIN

  CALLBACK (action 3, 1 component):
    - Destroy - intended to clean up summoned debris

The callback's targeting flags inherit Tgt_Obj_Radius from the default AoE,
plus Tgt_Summoned_No_Obj from the callback-specific override. This means
target_context_build_list enumerates ALL objects in the blast radius, then
target_context_evaluate filters them. Only summoned objects should pass.

With the bug: the dead critter has OF_PROVIDES_COVER (0x4000) in OBJ_F_FLAGS,
so `(flags & 0x4000) != 0` - the check thinks it IS summoned. The critter
enters the target list and MTComponentDestroy_ProcFunc calls object_destroy()
on it, interrupting the dying animation and making the body vanish.

With the fix: `(spell_flags & 0x4000) == 0` correctly identifies the critter
as not summoned. It is rejected from the target list. Only the debris is
destroyed. The dying animation completes normally and the body persists.


</details> 