### PR TITLE
fix(trap): pass placed trap object to timer instead of already-destroyed inventory item

### DIFF
--- a/src/game/trap.c
+++ b/src/game/trap.c
@@ -370,7 +370,7 @@ bool trap_use_at_loc(int64_t pc_obj, int64_t item_obj, int64_t target_loc)
     UiMessage ui_message;
     int spl;
     int64_t prototype_handle;
-    int64_t trap_obj;
+    int64_t trap_obj = OBJ_HANDLE_NULL;
     int name;
 
     spl = obj_field_int32_get(item_obj, OBJ_F_ITEM_SPELL_2);
@@ -396,7 +396,7 @@ bool trap_use_at_loc(int64_t pc_obj, int64_t item_obj, int64_t target_loc)
             }
         }
 
-        trap_timeevent_schedule(spl, target_loc, 88, item_obj);
+        trap_timeevent_schedule(spl, target_loc, 88, trap_obj);
         return true;
     }
 


### PR DESCRIPTION
A minimal, AI-assisted, cross checked vs. the OG Arcanum binary fix for the following bug:

when planting dynamite at a ground tile, trap_use_at_loc destroys the inventory item, creates a lit dynamite scenery object, but then passes the already-destroyed inventory handle to the explosion timer instead of the new scenery handle. So when the timer fires, the scenery is never cleaned up.

---

https://github.com/user-attachments/assets/83f37c7e-e03b-494f-9065-57f96d4cc3a6

---

<details><summary>Details</summary>

### Fix: pass placed trap object to timer instead of already-destroyed inventory item

```c
// BEFORE (wrong):
trap_timeevent_schedule(spl, target_loc, 88, item_obj);   // already destroyed

// AFTER (matches OG):
int64_t trap_obj = OBJ_HANDLE_NULL;
// ... object_create(prototype_handle, target_loc, &trap_obj) ...
trap_timeevent_schedule(spl, target_loc, 88, trap_obj);   // the placed scenery
```

### OG binary verification

The OG is a 32-bit binary (PE32 Intel 80386), but the engine uses 64-bit object handles internally, passed as two 32-bit words. The function reuses stack slots `[esp+0x48]`/`[esp+0x4c]` for the trap object handle: zeroes both before the switch, writes via `object_create`, then reads them back for `trap_timeevent_schedule`.

**Step 1 - zero the handle (`0x4BC4BF`):**

```asm
4bc4bf:  xor    eax, eax                         ; eax = 0
4bc4c7:  mov    DWORD PTR [esp+0x48], eax        ; trap_obj_lo = 0
4bc4cb:  mov    DWORD PTR [esp+0x4c], eax        ; trap_obj_hi = 0
```

**Step 2 - create scenery into that slot (`0x4BC502`):**

```asm
4bc502:  lea    ecx, [esp+0x48]                  ; ecx = &trap_obj
4bc506:  push   ecx                              ; push &trap_obj (out param)
4bc50f:  call   0x43cba0                         ; object_create(..., &trap_obj)
```

**Step 3 - pass trap_obj to timer (`0x4BC545`):**

```asm
4bc545:  mov    eax, DWORD PTR [esp+0x4c]        ; eax = trap_obj_hi
4bc549:  mov    ecx, DWORD PTR [esp+0x48]        ; ecx = trap_obj_lo
4bc551:  push   eax                              ; \ item_obj arg =
4bc552:  push   ecx                              ; / trap_obj (the scenery)
4bc553:  push   0x58                             ; delay = 88
4bc558:  call   0x4bc690                         ; trap_timeevent_schedule
```

`[esp+0x48]`/`[esp+0x4c]` hold the output of `object_create` (the placed scenery), not the original `item_obj` (which lived in `edi`/`esi` and was destroyed earlier at `0x4BC4A9`). The CE mistakenly passed the wrong variable.

</details> 

