### PR TITLE
fix(anim): remove inverted net guard that kept critters stunned indefinitely

### DIFF
--- a/src/game/anim.c
+++ b/src/game/anim.c
@@ -5552,11 +5552,6 @@ bool AGendAnimStunAnim(AnimRunInfo* run_info)
         return false;
     }
 
-    if (tig_net_is_active()
-        || !tig_net_is_host()) {
-        return false;
-    }
-
     if (!combat_turn_based_is_active()) {
         run_info->cur_stack_data->params[AGDATA_SCRATCH_VAL5].data--;
     }


### PR DESCRIPTION
Fiexes #130 

There is a logical bug in the MP related guard, but since CE drops MP anyways I deleted entire guard.