### PR TITLE
fix(item): ammo transfer overwrites recipient's ammo quantity

### DIFF
--- a/src/game/item.c
+++ b/src/game/item.c
@@ -3150,7 +3150,7 @@ bool item_ammo_transfer(int64_t from_obj, int64_t to_obj, int qty, int ammo_type
     if (to_obj != OBJ_HANDLE_NULL) {
         to_ammo_obj = item_ammo_obj(to_obj, ammo_type);
         if (to_ammo_obj != OBJ_HANDLE_NULL) {
-            remaining_qty = obj_field_int32_get(ammo_obj, OBJ_F_AMMO_QUANTITY);
+            remaining_qty = obj_field_int32_get(to_ammo_obj, OBJ_F_AMMO_QUANTITY);
             obj_field_int32_set(to_ammo_obj, OBJ_F_AMMO_QUANTITY, remaining_qty + qty);
         } else {
             to_ammo_obj = item_ammo_create(qty,


### PR DESCRIPTION
Fixes #132 , follow up on #111

Note, 
to keep the patch minimal I did not rename anything, but if renames like these applied:

```
int qty             -> int transfer_qty
int remaining_qty   -> int qty or current_qty 
```
the variable names would make more sense given the context they are used in.
