### PR TITLE
Misc fixes: ghost buttons, cursor, ESC, save/load shortcuts, overlay dismiss

### DIFF
--- a/first_party/tig/include/tig/button.h
+++ b/first_party/tig/include/tig/button.h
@@ -57,6 +57,7 @@ int tig_button_is_hidden(tig_button_handle_t button_handle, bool* hidden);
 int tig_button_show_force(tig_button_handle_t button_handle);
 int tig_button_hide_force(tig_button_handle_t button_handle);
 void tig_button_set_art(tig_button_handle_t button_handle, tig_art_id_t art_id);
+void tig_button_translate(tig_button_handle_t button_handle, int dx, int dy);
 
 #ifdef __cplusplus
 }

--- a/first_party/tig/include/tig/button.h
+++ b/first_party/tig/include/tig/button.h
@@ -48,6 +48,7 @@ int tig_button_refresh_rect(tig_window_handle_t window_handle, TigRect* rect);
 void tig_button_state_change(tig_button_handle_t button_handle, TigButtonState state);
 int tig_button_state_get(tig_button_handle_t button_handle, TigButtonState* state);
 tig_button_handle_t tig_button_get_at_position(int x, int y);
+tig_button_handle_t tig_button_get_hovered(void);
 bool tig_button_process_mouse_msg(TigMouseMessageData* mouse);
 int tig_button_radio_group_create(int count, tig_button_handle_t* button_handles, int selected);
 tig_button_handle_t sub_538730(tig_button_handle_t button_handle);

--- a/first_party/tig/src/button.c
+++ b/first_party/tig/src/button.c
@@ -877,3 +877,23 @@ void tig_button_set_art(tig_button_handle_t button_handle, tig_art_id_t art_id)
         tig_button_refresh_rect(btn->window_handle, &(btn->rect));
     }
 }
+
+// Shift a button's cached screen-absolute rect. Used when the button's parent
+// window is moved so subsequent refreshes blit the button art at the correct
+// window-local offset (refresh_rect computes dst as btn->rect minus the
+// current window frame).
+void tig_button_translate(tig_button_handle_t button_handle, int dx, int dy)
+{
+    TigButton* btn;
+    int button_index;
+
+    if (button_handle == TIG_BUTTON_HANDLE_INVALID) {
+        return;
+    }
+
+    button_index = tig_button_handle_to_index(button_handle);
+    btn = &(buttons[button_index]);
+
+    btn->rect.x += dx;
+    btn->rect.y += dy;
+}

--- a/first_party/tig/src/button.c
+++ b/first_party/tig/src/button.c
@@ -381,6 +381,18 @@ int tig_button_state_get(tig_button_handle_t button_handle, TigButtonState* stat
     return TIG_OK;
 }
 
+// Returns the button currently in the MOUSE_INSIDE state, or
+// TIG_BUTTON_HANDLE_INVALID if no button is hovered. Used by the modal
+// dialog system to replay a MOUSE_OUTSIDE notification for the
+// underlying menu's hovered button after the modal closes — the modal
+// loop drops button state-change messages while it's up, so the
+// underlying menu can't update its rendered highlight via the normal
+// notification path.
+tig_button_handle_t tig_button_get_hovered(void)
+{
+    return tig_button_hovered_button_handle;
+}
+
 // 0x5380F0
 tig_button_handle_t tig_button_get_at_position(int x, int y)
 {

--- a/first_party/tig/src/core.c
+++ b/first_party/tig/src/core.c
@@ -25,6 +25,18 @@
 typedef int (*TigInitFunc)(TigInitInfo* init_info);
 typedef void (*TigExitFunc)(void);
 
+static void tig_native_cursor_apply(void);
+static void tig_native_cursor_refresh(bool force);
+
+#ifdef __APPLE__
+/* macOS Game Overlay can restore the native arrow without a focus change
+ * when its launch banner dismisses, so we periodically ask SDL to redraw the
+ * currently selected cursor while the game is active. */
+enum {
+    TIG_MACOS_NATIVE_CURSOR_REFRESH_INTERVAL_MS = 100,
+};
+#endif
+
 typedef struct TigModule {
     const char* name;
     TigInitFunc init_func;
@@ -67,6 +79,9 @@ static bool in_tig_exit;
 // 0x60F244
 static bool tig_active;
 
+static SDL_Cursor* tig_blank_cursor;
+static tig_timestamp_t tig_native_cursor_refresh_timestamp;
+
 // 0x739F34
 tig_timestamp_t tig_ping_timestamp;
 
@@ -75,6 +90,7 @@ int tig_init(TigInitInfo* init_info)
 {
     size_t index;
     int rc;
+    SDL_Surface* blank_cursor_surface;
 
     if (tig_initialized) {
         return TIG_ERR_ALREADY_INITIALIZED;
@@ -83,6 +99,15 @@ int tig_init(TigInitInfo* init_info)
     if (!SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO | SDL_INIT_EVENTS)) {
         tig_debug_printf("Error initializing SDL: %s\n", SDL_GetError());
         return TIG_ERR_GENERIC;
+    }
+
+    blank_cursor_surface = SDL_CreateSurface(1, 1, SDL_PIXELFORMAT_RGBA32);
+    if (blank_cursor_surface != NULL) {
+        SDL_FillSurfaceRect(blank_cursor_surface,
+            NULL,
+            SDL_MapSurfaceRGBA(blank_cursor_surface, 0, 0, 0, 0));
+        tig_blank_cursor = SDL_CreateColorCursor(blank_cursor_surface, 0, 0);
+        SDL_DestroySurface(blank_cursor_surface);
     }
 
     atexit(SDL_Quit);
@@ -104,12 +129,18 @@ int tig_init(TigInitInfo* init_info)
                 modules[--index].exit_func();
             }
 
+            if (tig_blank_cursor != NULL) {
+                SDL_DestroyCursor(tig_blank_cursor);
+                tig_blank_cursor = NULL;
+            }
+
             return rc;
         }
     }
 
     atexit(tig_exit);
 
+    tig_set_active(true);
     tig_initialized = true;
 
     return TIG_OK;
@@ -132,6 +163,11 @@ void tig_exit(void)
             modules[--index].exit_func();
         }
 
+        if (tig_blank_cursor != NULL) {
+            SDL_DestroyCursor(tig_blank_cursor);
+            tig_blank_cursor = NULL;
+        }
+
         tig_initialized = false;
 
         in_tig_exit = false;
@@ -143,6 +179,7 @@ void tig_ping(void)
 {
     tig_timer_now(&tig_ping_timestamp);
 
+    tig_native_cursor_refresh(false);
     tig_mouse_ping();
     tig_message_ping();
     tig_sound_ping();
@@ -155,10 +192,58 @@ void tig_set_active(bool is_active)
     tig_active = is_active;
     tig_mouse_set_active(is_active);
     tig_sound_set_active(is_active);
+    tig_native_cursor_refresh(true);
 }
 
 // 0x51F320
 bool tig_get_active(void)
 {
     return tig_active;
+}
+
+void tig_native_cursor_apply(void)
+{
+    if (tig_active) {
+        if (tig_blank_cursor != NULL) {
+            SDL_SetCursor(tig_blank_cursor);
+            SDL_ShowCursor();
+        } else {
+            SDL_HideCursor();
+        }
+    } else {
+        SDL_SetCursor(SDL_GetDefaultCursor());
+        SDL_ShowCursor();
+    }
+}
+
+void tig_native_cursor_refresh(bool force)
+{
+    if (!tig_initialized && !force) {
+        return;
+    }
+
+    if (tig_active) {
+#ifdef __APPLE__
+        if (!force
+            && tig_timer_between(tig_native_cursor_refresh_timestamp, tig_ping_timestamp) < TIG_MACOS_NATIVE_CURSOR_REFRESH_INTERVAL_MS) {
+            return;
+        }
+
+        tig_native_cursor_apply();
+
+        /* SDL_SetCursor(NULL) forces a Cocoa cursor redraw without changing the
+         * currently selected cursor object. This helps recover when macOS
+         * overlays restore the native arrow behind SDL's back. */
+        SDL_SetCursor(NULL);
+        tig_native_cursor_refresh_timestamp = tig_ping_timestamp;
+#else
+        if (force) {
+            tig_native_cursor_apply();
+            tig_native_cursor_refresh_timestamp = tig_ping_timestamp;
+        }
+#endif
+    } else if (force) {
+        tig_native_cursor_apply();
+        tig_native_cursor_refresh_timestamp = tig_ping_timestamp;
+    }
 }

--- a/first_party/tig/src/message.c
+++ b/first_party/tig/src/message.c
@@ -111,9 +111,11 @@ void tig_message_ping(void)
         SDL_ConvertEventToRenderCoordinates(renderer, &event);
 
         switch (event.type) {
+        case SDL_EVENT_WINDOW_FOCUS_GAINED:
         case SDL_EVENT_WINDOW_MOUSE_ENTER:
             tig_set_active(true);
             break;
+        case SDL_EVENT_WINDOW_FOCUS_LOST:
         case SDL_EVENT_WINDOW_MOUSE_LEAVE:
             tig_set_active(false);
             break;

--- a/first_party/tig/src/video.c
+++ b/first_party/tig/src/video.c
@@ -105,8 +105,6 @@ int tig_video_init(TigInitInfo* init_info)
     tig_video_show_fps = (init_info->flags & TIG_INITIALIZE_FPS) != 0;
     tig_video_bpp = init_info->bpp;
 
-    SDL_HideCursor();
-
     tig_video_screenshot_key = -1;
     dword_6103A4 = 0;
 

--- a/first_party/tig/src/window.c
+++ b/first_party/tig/src/window.c
@@ -1515,6 +1515,7 @@ int tig_window_modal_dialog(TigWindowModalDialogInfo* modal_info, TigWindowModal
 {
     TigMessage msg;
     TigWindowData window_data;
+    tig_button_handle_t hovered;
 
     if (modal_info == NULL) {
         return TIG_ERR_GENERIC;
@@ -1525,6 +1526,40 @@ int tig_window_modal_dialog(TigWindowModalDialogInfo* modal_info, TigWindowModal
     }
 
     tig_window_modal_dialog_info = *modal_info;
+
+    // Clear any active button hover BEFORE the modal opens so the
+    // underlying window (e.g. the main menu showing a highlighted
+    // "QUIT" item) un-highlights itself on the same frame the modal
+    // appears. Once the modal window is created its filter swallows
+    // every non-REDRAW message, including the TIG_MESSAGE_BUTTON
+    // state-change notifications that would normally drive the menu's
+    // morph-text refresh — so doing it here, before the swallow chain
+    // is in place, is the simplest path to a consistent rollover state.
+    hovered = tig_button_get_hovered();
+    if (hovered != TIG_BUTTON_HANDLE_INVALID) {
+        TigMessage notify;
+        notify.type = TIG_MESSAGE_BUTTON;
+        tig_timer_now(&(notify.timestamp));
+        notify.data.button.button_handle = hovered;
+        notify.data.button.state = TIG_BUTTON_STATE_MOUSE_OUTSIDE;
+        notify.data.button.x = 0;
+        notify.data.button.y = 0;
+        // Dispatch synchronously via the window filter chain. With no
+        // modal up yet, the menu's filter handles the BUTTON event,
+        // calls its refresh_button_text(idx, 0), and the morph-text
+        // re-renders without the highlight flag into the menu window's
+        // video buffer. Then sync the button system's own internal
+        // state so any art-based button using state-driven art also
+        // drops back to its idle frame.
+        tig_window_filter_message(&notify);
+        tig_button_state_change(hovered, TIG_BUTTON_STATE_MOUSE_OUTSIDE);
+        // Force a display pass to push the just-cleared vbuffer state
+        // to the screen BEFORE the modal window is created. Without
+        // this, the modal goes up over a screen that still shows the
+        // stale highlight — the menu's video buffer is correct but
+        // the compositor hasn't pushed the dirty rect yet.
+        tig_window_display();
+    }
 
     window_data.flags = TIG_WINDOW_MODAL | TIG_WINDOW_ALWAYS_ON_TOP;
     window_data.rect.width = MODAL_DIALOG_WIDTH;
@@ -1624,6 +1659,49 @@ bool tig_window_modal_dialog_message_filter(TigMessage* msg)
                 switch (tig_window_modal_dialog_info.type) {
                 case TIG_WINDOW_MODAL_DIALOG_TYPE_CANCEL:
                 case TIG_WINDOW_MODAL_DIALOG_TYPE_OK_CANCEL:
+                    tig_message_modal_dialog_choice = TIG_WINDOW_MODAL_DIALOG_CHOICE_CANCEL;
+                    tig_window_modal_dialog_close();
+                    break;
+                }
+            }
+        }
+        break;
+    case TIG_MESSAGE_MOUSE:
+        // Click-outside-the-modal dismisses, matching the click-outside
+        // overlay-dismiss behavior recently added to the main menu /
+        // overlay screens.  The modal flag swallows all mouse events
+        // anyway, so this handler is the only place that sees a click
+        // landing outside the dialog rect.  Dispatch:
+        //   - Inside the dialog rect: do nothing here; the button-press
+        //     path above already handles OK / Cancel clicks via
+        //     TIG_MESSAGE_BUTTON.
+        //   - Outside:
+        //       OK-only / OK_CANCEL → Cancel (safe non-destructive
+        //       default — e.g. clicking outside "Delete save?" or "Quit
+        //       game?" should NOT delete or quit).
+        //       CANCEL-only        → Cancel (only choice anyway).
+        if (msg->data.mouse.event == TIG_MESSAGE_MOUSE_LEFT_BUTTON_UP) {
+            TigWindowData wd;
+            if (tig_window_modal_dialog_window_handle != TIG_WINDOW_HANDLE_INVALID
+                && tig_window_data(tig_window_modal_dialog_window_handle, &wd) == TIG_OK
+                && (msg->data.mouse.x < wd.rect.x
+                    || msg->data.mouse.y < wd.rect.y
+                    || msg->data.mouse.x >= wd.rect.x + wd.rect.width
+                    || msg->data.mouse.y >= wd.rect.y + wd.rect.height)) {
+                switch (tig_window_modal_dialog_info.type) {
+                case TIG_WINDOW_MODAL_DIALOG_TYPE_OK:
+                    // Info / acknowledgment modal — OK is the only choice
+                    // and ANY keypress already dismisses with OK above.
+                    // Match: a click outside dismisses with OK.
+                    tig_message_modal_dialog_choice = TIG_WINDOW_MODAL_DIALOG_CHOICE_OK;
+                    tig_window_modal_dialog_close();
+                    break;
+                case TIG_WINDOW_MODAL_DIALOG_TYPE_CANCEL:
+                case TIG_WINDOW_MODAL_DIALOG_TYPE_OK_CANCEL:
+                    // Confirm prompts ("Quit?", "Delete this save?",
+                    // etc.) — a stray click outside should NEVER commit
+                    // the destructive choice. Cancel is the universal
+                    // safe default.
                     tig_message_modal_dialog_choice = TIG_WINDOW_MODAL_DIALOG_CHOICE_CANCEL;
                     tig_window_modal_dialog_close();
                     break;

--- a/first_party/tig/src/window.c
+++ b/first_party/tig/src/window.c
@@ -1787,18 +1787,36 @@ int tig_window_move(tig_window_handle_t window_handle, int x, int y)
 {
     int window_index;
     TigWindow* win;
+    int dx;
+    int dy;
+    int i;
 
     window_index = tig_window_handle_to_index(window_handle);
     win = &(windows[window_index]);
 
-    if ((win->flags & TIG_WINDOW_HIDDEN) != 0) {
+    // Invalidate old frame area so the previous position is recomposited
+    // from underlying windows.
+    if ((win->flags & TIG_WINDOW_HIDDEN) == 0) {
         tig_window_invalidate_rect(&(win->frame));
     }
+
+    dx = x - win->frame.x;
+    dy = y - win->frame.y;
 
     win->frame.x = x;
     win->frame.y = y;
 
-    if ((win->flags & TIG_WINDOW_HIDDEN) != 0) {
+    // Child buttons cache absolute screen rects (set at creation as
+    // window.frame + button-local offset). Translate them by the same delta
+    // so subsequent button refreshes blit art at the correct window-local
+    // offset; otherwise the stale rect minus the moved frame yields a
+    // wrong destination and the button art is baked into the strip's
+    // pixel buffer at the wrong place (ghost buttons).
+    for (i = 0; i < win->num_buttons; i++) {
+        tig_button_translate(win->buttons[i], dx, dy);
+    }
+
+    if ((win->flags & TIG_WINDOW_HIDDEN) == 0) {
         tig_window_invalidate_rect(&(win->frame));
     }
 

--- a/first_party/tig/src/window.c
+++ b/first_party/tig/src/window.c
@@ -1579,7 +1579,13 @@ bool tig_window_modal_dialog_message_filter(TigMessage* msg)
 {
     switch (msg->type) {
     case TIG_MESSAGE_KEYBOARD:
-        if (msg->data.keyboard.pressed) {
+        // Close the modal on keyup, not keydown. The matching keyup is
+        // still queued behind a keydown-closed modal and was leaking out
+        // to the underlying message loop (e.g. mainmenu_ui_handle's ESC
+        // handler), so dismissing a confirm dialog with ESC was also
+        // closing the menu that opened it. Handling on keyup means the
+        // modal swallows both events before anything else sees them.
+        if (!msg->data.keyboard.pressed) {
             switch (tig_window_modal_dialog_info.type) {
             case TIG_WINDOW_MODAL_DIALOG_TYPE_OK:
                 tig_message_modal_dialog_choice = TIG_WINDOW_MODAL_DIALOG_CHOICE_OK;

--- a/src/main.c
+++ b/src/main.c
@@ -484,6 +484,29 @@ void main_loop(void)
                         sub_543220();
                         mainmenu_ui_feedback_loading_completed();
                         break;
+                    case SDL_SCANCODE_S:
+                        // Ctrl/Cmd+S → Save Game menu (in-game shortcut).
+                        // Accepts either modifier so the platform-native
+                        // convention (Cmd on macOS, Ctrl on Windows/Linux)
+                        // works everywhere.
+                        if (!textedit_ui_is_focused()
+                            && tig_kb_get_modifier(SDL_KMOD_CTRL | SDL_KMOD_GUI)) {
+                            mainmenu_ui_start_at_window(MM_WINDOW_SAVE_GAME);
+                            if (!mainmenu_ui_handle()) {
+                                return;
+                            }
+                        }
+                        break;
+                    case SDL_SCANCODE_L:
+                        // Ctrl/Cmd+L → Load Game menu (in-game shortcut).
+                        if (!textedit_ui_is_focused()
+                            && tig_kb_get_modifier(SDL_KMOD_CTRL | SDL_KMOD_GUI)) {
+                            mainmenu_ui_start_at_window(MM_WINDOW_LOAD_GAME);
+                            if (!mainmenu_ui_handle()) {
+                                return;
+                            }
+                        }
+                        break;
                     case SDL_SCANCODE_F11:
                         if (gamelib_cheat_level_get() >= 3) {
                             for (index = 0; index < SPELL_COUNT; index++) {

--- a/src/main.c
+++ b/src/main.c
@@ -425,8 +425,7 @@ void main_loop(void)
                     case SDL_SCANCODE_ESCAPE: {
                         IntgameMode esc_mode = intgame_mode_get();
                         if (esc_mode != INTGAME_MODE_MAIN
-                            && esc_mode != INTGAME_MODE_DIALOG
-                            && esc_mode != INTGAME_MODE_BARTER) {
+                            && esc_mode != INTGAME_MODE_DIALOG) {
                             intgame_mode_set(INTGAME_MODE_MAIN);
                             break;
                         }

--- a/src/main.c
+++ b/src/main.c
@@ -451,8 +451,14 @@ void main_loop(void)
                         tig_debug_printf("completed.\n");
                         break;
                     case SDL_SCANCODE_O:
+                        // Plain O → Options menu (existing in-game shortcut).
+                        // Cmd/Ctrl+O → Load Game menu (mnemonic: "Open").
                         if (!textedit_ui_is_focused()) {
-                            mainmenu_ui_start(MM_TYPE_OPTIONS);
+                            if (tig_kb_get_modifier(SDL_KMOD_CTRL | SDL_KMOD_GUI)) {
+                                mainmenu_ui_start_at_window(MM_WINDOW_LOAD_GAME);
+                            } else {
+                                mainmenu_ui_start(MM_TYPE_OPTIONS);
+                            }
                             if (!mainmenu_ui_handle()) {
                                 return;
                             }
@@ -485,26 +491,47 @@ void main_loop(void)
                         mainmenu_ui_feedback_loading_completed();
                         break;
                     case SDL_SCANCODE_S:
-                        // Ctrl/Cmd+S → Save Game menu (in-game shortcut).
-                        // Accepts either modifier so the platform-native
+                        // Cmd/Ctrl+S       → quicksave (same as F7)
+                        // Cmd/Ctrl+Shift+S → Save Game menu
+                        // Accepts either Cmd or Ctrl so the platform-native
                         // convention (Cmd on macOS, Ctrl on Windows/Linux)
                         // works everywhere.
                         if (!textedit_ui_is_focused()
                             && tig_kb_get_modifier(SDL_KMOD_CTRL | SDL_KMOD_GUI)) {
-                            mainmenu_ui_start_at_window(MM_WINDOW_SAVE_GAME);
-                            if (!mainmenu_ui_handle()) {
-                                return;
+                            if (tig_kb_get_modifier(SDL_KMOD_SHIFT)) {
+                                mainmenu_ui_start_at_window(MM_WINDOW_SAVE_GAME);
+                                if (!mainmenu_ui_handle()) {
+                                    return;
+                                }
+                            } else if (!critter_is_dead(player_get_local_pc_obj())) {
+                                if (wmap_ui_is_created()) {
+                                    wmap_ui_close();
+                                    tig_ping();
+                                    gamelib_ping();
+                                    iso_redraw();
+                                    tig_window_display();
+                                }
+                                if (!combat_turn_based_is_active()
+                                    || player_get_local_pc_obj() == combat_turn_based_whos_turn_get()) {
+                                    intgame_mode_set(INTGAME_MODE_MAIN);
+                                    intgame_mode_set(INTGAME_MODE_MAIN);
+                                    mainmenu_ui_feedback_saving();
+                                    gamelib_save("SlotAuto", "Auto-Save");
+                                    mainmenu_ui_feedback_saving_completed();
+                                } else {
+                                    mainmenu_ui_feedback_cannot_save_in_tb();
+                                }
                             }
                         }
                         break;
                     case SDL_SCANCODE_L:
-                        // Ctrl/Cmd+L → Load Game menu (in-game shortcut).
+                        // Cmd/Ctrl+L → quickload (same as F8).
                         if (!textedit_ui_is_focused()
-                            && tig_kb_get_modifier(SDL_KMOD_CTRL | SDL_KMOD_GUI)) {
-                            mainmenu_ui_start_at_window(MM_WINDOW_LOAD_GAME);
-                            if (!mainmenu_ui_handle()) {
-                                return;
-                            }
+                            && tig_kb_get_modifier(SDL_KMOD_CTRL | SDL_KMOD_GUI)
+                            && !tig_kb_get_modifier(SDL_KMOD_SHIFT)) {
+                            mainmenu_ui_feedback_loading();
+                            sub_543220();
+                            mainmenu_ui_feedback_loading_completed();
                         }
                         break;
                     case SDL_SCANCODE_F11:

--- a/src/ui/charedit_ui.c
+++ b/src/ui/charedit_ui.c
@@ -1579,6 +1579,19 @@ bool charedit_window_message_filter(TigMessage* msg)
                 charedit_close();
                 return true;
             }
+            // Click outside the charedit window and outside both HUD strips
+            // dismisses the overlay (hi-res convenience). Skipped during
+            // creation modes which need explicit Done/Cancel.
+            if (charedit_mode != CHAREDIT_MODE_CREATE
+                && charedit_mode != CHAREDIT_MODE_3
+                && charedit_window_handle != TIG_WINDOW_HANDLE_INVALID) {
+                TigWindowData menu_wd;
+                if (tig_window_data(charedit_window_handle, &menu_wd) == TIG_OK
+                    && intgame_should_dismiss_overlay_click(msg->data.mouse.x, msg->data.mouse.y, &menu_wd.rect)) {
+                    charedit_close();
+                    return true;
+                }
+            }
             return false;
         default:
             return false;

--- a/src/ui/dialog_ui.c
+++ b/src/ui/dialog_ui.c
@@ -307,6 +307,10 @@ bool dialog_ui_process_option(DialogUiEntry* entry, int option)
     case 3:
         if (is_pc) {
             intgame_dialog_clear();
+            // CE: the dialogue option fired on mouse-DOWN; suppress the
+            // paired mouse-UP so it doesn't instantly dismiss the
+            // just-opened overlay via the click-outside-dismiss path.
+            intgame_suppress_overlay_dismiss_once();
             inven_ui_open(entry->state.pc_obj, entry->state.npc_obj, INVEN_UI_MODE_BARTER);
         }
         break;
@@ -322,30 +326,35 @@ bool dialog_ui_process_option(DialogUiEntry* entry, int option)
     case 5:
         if (is_pc) {
             intgame_dialog_clear();
+            intgame_suppress_overlay_dismiss_once();
             charedit_open(entry->state.npc_obj, CHAREDIT_MODE_PASSIVE);
         }
         break;
     case 6:
         if (is_pc) {
             intgame_dialog_clear();
+            intgame_suppress_overlay_dismiss_once();
             wmap_ui_open();
         }
         break;
     case 7:
         if (is_pc) {
             intgame_dialog_clear();
+            intgame_suppress_overlay_dismiss_once();
             schematic_ui_toggle(entry->state.npc_obj, entry->state.pc_obj);
         }
         break;
     case 8:
         if (is_pc) {
             intgame_dialog_clear();
+            intgame_suppress_overlay_dismiss_once();
             ui_show_inven_npc_identify(entry->state.pc_obj, entry->state.npc_obj);
         }
         break;
     case 9:
         if (is_pc) {
             intgame_dialog_clear();
+            intgame_suppress_overlay_dismiss_once();
             inven_ui_open(entry->state.pc_obj, entry->state.npc_obj, INVEN_UI_MODE_NPC_REPAIR);
         }
         break;

--- a/src/ui/intgame.c
+++ b/src/ui/intgame.c
@@ -2537,6 +2537,11 @@ bool sub_54B5D0(TigMessage* msg)
                 gsound_play_sfx(0, 1);
                 return true;
             case SDLK_S:
+                // Plain S opens the sleep menu; let Ctrl/Cmd+S fall through
+                // to main.c's Save Game shortcut.
+                if (tig_kb_get_modifier(SDL_KMOD_CTRL | SDL_KMOD_GUI)) {
+                    return false;
+                }
                 sleep_ui_toggle(OBJ_HANDLE_NULL);
                 gsound_play_sfx(0, 1);
                 return true;

--- a/src/ui/intgame.c
+++ b/src/ui/intgame.c
@@ -4523,9 +4523,37 @@ bool intgame_pc_lens_check_pt_unscale(int x, int y)
 // The 800x600 HUD strips are 800px wide and centered horizontally at hi-res,
 // so empty screen area to either side of the strip (in the surrounding world
 // view) is correctly treated as "outside HUD" and triggers dismissal.
+// CE: one-shot guard against a stray click-outside dismiss. Overlays
+// opened from a DIALOGUE option (worldmap / barter / charedit /
+// schematic / identify) are selected on LEFT_BUTTON_DOWN —
+// tc_handle_message only acts on mouse-down, dialogue options are
+// mouse-only — so the paired LEFT_BUTTON_UP lands on the freshly
+// opened overlay, outside its window, and would trip
+// intgame_should_dismiss_overlay_click → instant close. The dialogue
+// option handler arms this flag at the open; the next dismiss check
+// (the paired mouse-up, the only event that calls the helper) clears
+// it and returns false instead of dismissing. Because dialogue
+// selection is mouse-only the paired up is guaranteed, so the flag is
+// never left dangling for a keyboard path.
+static bool intgame_overlay_dismiss_suppress_once = false;
+
+void intgame_suppress_overlay_dismiss_once(void)
+{
+    intgame_overlay_dismiss_suppress_once = true;
+}
+
 bool intgame_should_dismiss_overlay_click(int screen_x, int screen_y, const TigRect* menu_rect)
 {
     TigRect strip;
+
+    // Consume the one stray mouse-up that pairs with the dialogue
+    // option's mouse-down (see intgame_suppress_overlay_dismiss_once).
+    // The helper is only ever called on LEFT_BUTTON_UP, so the first
+    // call after a dialogue-driven open is exactly that stray up.
+    if (intgame_overlay_dismiss_suppress_once) {
+        intgame_overlay_dismiss_suppress_once = false;
+        return false;
+    }
 
     if (menu_rect == NULL) {
         return false;

--- a/src/ui/intgame.c
+++ b/src/ui/intgame.c
@@ -4516,6 +4516,49 @@ bool intgame_pc_lens_check_pt_unscale(int x, int y)
     return intgame_pc_lens_check_pt(x, y);
 }
 
+// True if a mouse click should dismiss an overlay menu: the click is
+// outside the given menu rect AND not on either of the iso-interface HUD
+// strips. All coordinates are in screen space.
+//
+// The 800x600 HUD strips are 800px wide and centered horizontally at hi-res,
+// so empty screen area to either side of the strip (in the surrounding world
+// view) is correctly treated as "outside HUD" and triggers dismissal.
+bool intgame_should_dismiss_overlay_click(int screen_x, int screen_y, const TigRect* menu_rect)
+{
+    TigRect strip;
+
+    if (menu_rect == NULL) {
+        return false;
+    }
+
+    if (screen_x >= menu_rect->x
+        && screen_x < menu_rect->x + menu_rect->width
+        && screen_y >= menu_rect->y
+        && screen_y < menu_rect->y + menu_rect->height) {
+        return false;
+    }
+
+    strip = intgame_interface_window_frames[0];
+    hrp_apply(&strip, GRAVITY_CENTER_HORIZONTAL | GRAVITY_TOP);
+    if (screen_x >= strip.x
+        && screen_x < strip.x + strip.width
+        && screen_y >= strip.y
+        && screen_y < strip.y + strip.height) {
+        return false;
+    }
+
+    strip = intgame_interface_window_frames[1];
+    hrp_apply(&strip, GRAVITY_CENTER_HORIZONTAL | GRAVITY_BOTTOM);
+    if (screen_x >= strip.x
+        && screen_x < strip.x + strip.width
+        && screen_y >= strip.y
+        && screen_y < strip.y + strip.height) {
+        return false;
+    }
+
+    return true;
+}
+
 // 0x551080
 void intgame_pc_lens_redraw(void)
 {

--- a/src/ui/intgame.h
+++ b/src/ui/intgame.h
@@ -103,6 +103,13 @@ void intgame_pc_lens_do(PcLensMode mode, PcLens* pc_lens);
 bool intgame_pc_lens_check_pt(int x, int y);
 bool intgame_pc_lens_check_pt_unscale(int x, int y);
 bool intgame_should_dismiss_overlay_click(int screen_x, int screen_y, const TigRect* menu_rect);
+
+// CE: arm a one-shot suppression of the next overlay click-outside
+// dismiss. Call right before opening an overlay from a dialogue
+// option so the mouse-up that pairs with the option's mouse-down
+// doesn't immediately dismiss the just-opened overlay. See the
+// definition in intgame.c for the full rationale.
+void intgame_suppress_overlay_dismiss_once(void);
 void intgame_pc_lens_redraw(void);
 void iso_interface_refresh(void);
 bool sub_5517A0(TigMessage* msg);

--- a/src/ui/intgame.h
+++ b/src/ui/intgame.h
@@ -102,6 +102,7 @@ void intgame_message_window_clear_internal(void);
 void intgame_pc_lens_do(PcLensMode mode, PcLens* pc_lens);
 bool intgame_pc_lens_check_pt(int x, int y);
 bool intgame_pc_lens_check_pt_unscale(int x, int y);
+bool intgame_should_dismiss_overlay_click(int screen_x, int screen_y, const TigRect* menu_rect);
 void intgame_pc_lens_redraw(void);
 void iso_interface_refresh(void);
 bool sub_5517A0(TigMessage* msg);

--- a/src/ui/inven_ui.c
+++ b/src/ui/inven_ui.c
@@ -1819,6 +1819,22 @@ static inline bool inven_ui_message_filter_handle_mouse_lbutton_up(int x, int y,
         return false;
     }
 
+    // Click outside the inventory window and outside both HUD strips
+    // dismisses the overlay (hi-res convenience; at 800x600 nothing falls
+    // outside both menu and HUD so behavior is unchanged).
+    if (!mainmenu_ui_is_active()
+        && inven_ui_drag_item_obj == OBJ_HANDLE_NULL
+        && inven_ui_window_handle != TIG_WINDOW_HANDLE_INVALID) {
+        TigWindowData menu_wd;
+        int screen_x = x + (hrp_iso_window_width_get() - 800) / 2;
+        int screen_y = y + (hrp_iso_window_height_get() - 600) / 2;
+        if (tig_window_data(inven_ui_window_handle, &menu_wd) == TIG_OK
+            && intgame_should_dismiss_overlay_click(screen_x, screen_y, &menu_wd.rect)) {
+            *v45 = true;
+            return false;
+        }
+    }
+
     if (inven_ui_drag_item_obj == OBJ_HANDLE_NULL) {
         v1 = sub_575FA0(x, y, &v2);
         if (v1 == OBJ_HANDLE_NULL) {

--- a/src/ui/inven_ui.c
+++ b/src/ui/inven_ui.c
@@ -1795,7 +1795,14 @@ static inline bool inven_ui_message_filter_handle_mouse_lbutton_up(int x, int y,
 {
     int64_t v1;
     int64_t v2;
-
+    // Capture whether *this* inven_ui session received the matching
+    // mouse-down before we clear the flag. Used below to guard the
+    // dismiss-on-click paths against a stray mouse-up whose down came
+    // from a different window — most importantly the dialog "Trade"
+    // option that opens BARTER: dialog handles the down, barter handles
+    // the up, and without this guard the up would immediately close the
+    // just-opened barter screen.
+    bool inven_saw_down = (dword_68346C != 0);
     dword_68346C = 0;
     if (intgame_pc_lens_check_pt_unscale(x, y)) {
         if (!mainmenu_ui_is_active()) {
@@ -1813,7 +1820,9 @@ static inline bool inven_ui_message_filter_handle_mouse_lbutton_up(int x, int y,
                 sub_575770();
             }
 
-            *v45 = true;
+            if (inven_saw_down) {
+                *v45 = true;
+            }
         }
 
         return false;
@@ -1822,7 +1831,11 @@ static inline bool inven_ui_message_filter_handle_mouse_lbutton_up(int x, int y,
     // Click outside the inventory window and outside both HUD strips
     // dismisses the overlay (hi-res convenience; at 800x600 nothing falls
     // outside both menu and HUD so behavior is unchanged).
-    if (!mainmenu_ui_is_active()
+    // Requires inven_saw_down so a stray mouse-up from a click that
+    // started in dialog (e.g. the "Trade" option that opens barter)
+    // doesn't immediately dismiss the freshly opened panel.
+    if (inven_saw_down
+        && !mainmenu_ui_is_active()
         && inven_ui_drag_item_obj == OBJ_HANDLE_NULL
         && inven_ui_window_handle != TIG_WINDOW_HANDLE_INVALID) {
         TigWindowData menu_wd;

--- a/src/ui/logbook_ui.c
+++ b/src/ui/logbook_ui.c
@@ -693,6 +693,17 @@ bool logbook_ui_message_filter(TigMessage* msg)
             logbook_ui_close();
             return true;
         }
+        // Click outside the logbook window and outside both HUD strips
+        // dismisses the overlay (hi-res convenience).
+        if (msg->data.mouse.event == TIG_MESSAGE_MOUSE_LEFT_BUTTON_UP
+            && logbook_ui_window != TIG_WINDOW_HANDLE_INVALID) {
+            TigWindowData menu_wd;
+            if (tig_window_data(logbook_ui_window, &menu_wd) == TIG_OK
+                && intgame_should_dismiss_overlay_click(msg->data.mouse.x, msg->data.mouse.y, &menu_wd.rect)) {
+                logbook_ui_close();
+                return true;
+            }
+        }
         return false;
     }
 

--- a/src/ui/mainmenu_ui.c
+++ b/src/ui/mainmenu_ui.c
@@ -1787,13 +1787,15 @@ bool mainmenu_ui_handle(void)
                 if (!msg.data.keyboard.pressed
                     && msg.data.keyboard.scancode == SDL_SCANCODE_ESCAPE
                     && mainmenu_ui_window_type != MM_WINDOW_MAINMENU) {
-                    // For menu types whose primary action is "exit to game"
-                    // (in-play pause menu, in-play locked, and the in-game
-                    // Options shortcut), route ESC through the same full
-                    // exit path the Done button uses so intgame_show() and
-                    // the rest of the restore steps run. Otherwise just pop
-                    // the menu stack the usual way.
-                    if (stru_5C36B0[mainmenu_ui_type][0]) {
+                    // If the menu stack has a parent (e.g. user opened
+                    // Options from the pause menu, or Save/Load from the
+                    // pause menu), pop back to the parent like the original
+                    // close-back path does. Only at the top of the stack —
+                    // i.e. we were launched directly into this menu (O key,
+                    // Cmd+S/L, etc.) — do we route ESC through the full
+                    // exit-to-game restore for the "in-game" menu types.
+                    if (mainmenu_ui_num_windows <= 1
+                        && stru_5C36B0[mainmenu_ui_type][0]) {
                         sub_5412D0();
                     } else {
                         mainmenu_ui_close(true);
@@ -5084,17 +5086,21 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
         case TIG_MESSAGE_MOUSE_LEFT_BUTTON_UP:
             // Click outside the menu's actual screen rect and outside both
             // HUD strips dismisses any "in-game" overlay menu — same effect
-            // as ESC or clicking the PC lens. Querying the live menu rect
-            // (rather than assuming 800x600) keeps this correct for partial
-            // menus too. At 800x600 native nothing falls outside both menu
-            // and HUD, so the original behavior is preserved.
+            // as ESC or clicking the PC lens. If the menu has a parent on
+            // the stack (e.g. Options reached from the pause menu), pop
+            // back to the parent; only fully exit to game when we're at
+            // the top of the stack.
             if (stru_5C36B0[mainmenu_ui_type][0]
                 && mainmenu_ui_window_handle != TIG_WINDOW_HANDLE_INVALID) {
                 TigWindowData menu_wd;
                 if (tig_window_data(mainmenu_ui_window_handle, &menu_wd) == TIG_OK
                     && intgame_should_dismiss_overlay_click(
                            original_screen_x, original_screen_y, &menu_wd.rect)) {
-                    sub_5412D0();
+                    if (mainmenu_ui_num_windows <= 1) {
+                        sub_5412D0();
+                    } else {
+                        mainmenu_ui_close(true);
+                    }
                     return true;
                 }
             }

--- a/src/ui/mainmenu_ui.c
+++ b/src/ui/mainmenu_ui.c
@@ -5279,13 +5279,6 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
                 mainmenu_ui_open();
                 return true;
             case MM_WINDOW_MAINMENU:
-                if (msg->data.keyboard.scancode == SDL_SCANCODE_ESCAPE
-                    && dword_64C43C > 1) {
-                    gsound_play_sfx(0, 1);
-                    sub_5412D0();
-                    mainmenu_ui_window_type = 0;
-                    mainmenu_ui_exit_game();
-                }
                 return false;
             case MM_WINDOW_OPTIONS:
                 if (msg->data.keyboard.scancode == SDL_SCANCODE_O) {

--- a/src/ui/mainmenu_ui.c
+++ b/src/ui/mainmenu_ui.c
@@ -5346,7 +5346,16 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
                 return false;
             case MM_WINDOW_OPTIONS:
                 if (msg->data.keyboard.scancode == SDL_SCANCODE_O) {
-                    if (!stru_5C36B0[mainmenu_ui_type][1]) {
+                    // O toggles Options closed only when we entered here
+                    // directly via the in-game O shortcut (top of menu
+                    // stack). When stacked under another menu — e.g. pause
+                    // menu → Options via its "O" hotkey button — the keyup
+                    // raced in here right after the keydown opened the
+                    // window and was auto-dismissing it. Swallow the key
+                    // either way so it doesn't fall through to other
+                    // handlers.
+                    if (!stru_5C36B0[mainmenu_ui_type][1]
+                        && mainmenu_ui_num_windows <= 1) {
                         sub_5412D0();
                     }
                     return true;

--- a/src/ui/mainmenu_ui.c
+++ b/src/ui/mainmenu_ui.c
@@ -5095,7 +5095,7 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
                 TigWindowData menu_wd;
                 if (tig_window_data(mainmenu_ui_window_handle, &menu_wd) == TIG_OK
                     && intgame_should_dismiss_overlay_click(
-                           original_screen_x, original_screen_y, &menu_wd.rect)) {
+                        original_screen_x, original_screen_y, &menu_wd.rect)) {
                     if (mainmenu_ui_num_windows <= 1) {
                         sub_5412D0();
                     } else {

--- a/src/ui/mainmenu_ui.c
+++ b/src/ui/mainmenu_ui.c
@@ -1761,7 +1761,17 @@ bool mainmenu_ui_handle(void)
                 if (!msg.data.keyboard.pressed
                     && msg.data.keyboard.scancode == SDL_SCANCODE_ESCAPE
                     && mainmenu_ui_window_type != MM_WINDOW_MAINMENU) {
-                    mainmenu_ui_close(true);
+                    // For menu types whose primary action is "exit to game"
+                    // (in-play pause menu, in-play locked, and the in-game
+                    // Options shortcut), route ESC through the same full
+                    // exit path the Done button uses so intgame_show() and
+                    // the rest of the restore steps run. Otherwise just pop
+                    // the menu stack the usual way.
+                    if (stru_5C36B0[mainmenu_ui_type][0]) {
+                        sub_5412D0();
+                    } else {
+                        mainmenu_ui_close(true);
+                    }
                 }
                 break;
             default:

--- a/src/ui/mainmenu_ui.c
+++ b/src/ui/mainmenu_ui.c
@@ -2198,7 +2198,12 @@ bool mainmenu_ui_press_options(tig_button_handle_t button_handle)
         }
     }
 
-    if (stru_5C36B0[mainmenu_ui_type][0]) {
+    // Same stack-aware close as ESC: if Options was reached via a parent
+    // menu (e.g. pause menu → Options), pop back to that parent. Only
+    // fully exit to game when we're at the top of the stack (the O key
+    // shortcut or similar direct entry).
+    if (mainmenu_ui_num_windows <= 1
+        && stru_5C36B0[mainmenu_ui_type][0]) {
         sub_5412D0();
     } else {
         mainmenu_ui_close(true);
@@ -5703,7 +5708,18 @@ void sub_5480C0(int a1)
         return;
     case 3:
         if (mainmenu_ui_window_type != MM_WINDOW_OPTIONS || options_ui_load_module()) {
-            mainmenu_ui_close(true);
+            // Same stack-aware close as ESC: when this menu was launched
+            // directly into the world (Cmd+Shift+S, Cmd+O, etc. — top of
+            // stack with an "exit to game" type), route through sub_5412D0
+            // so intgame_show() and the rest of the restore steps run.
+            // When stacked under a parent menu (pause menu → Save/Load),
+            // fall back to the normal close-back that pops to the parent.
+            if (mainmenu_ui_num_windows <= 1
+                && stru_5C36B0[mainmenu_ui_type][0]) {
+                sub_5412D0();
+            } else {
+                mainmenu_ui_close(true);
+            }
         }
         return;
     case 4:

--- a/src/ui/mainmenu_ui.c
+++ b/src/ui/mainmenu_ui.c
@@ -2147,7 +2147,9 @@ void mainmenu_ui_create_options(void)
         location_origin_set(loc);
         intgame_pc_lens_do(PC_LENS_MODE_PASSTHROUGH, &pc_lens);
     } else {
-        intgame_pc_lens_do(PC_LENS_MODE_BLACKOUT, &pc_lens);
+        // Pre-game (main menu) Options has no PC to look at — hide the lens
+        // entirely instead of showing the blacked-out widget.
+        intgame_pc_lens_do(PC_LENS_MODE_NONE, NULL);
     }
 
     tig_window_display();
@@ -2326,7 +2328,13 @@ void mainmenu_ui_load_game_create(void)
         location_origin_set(obj_field_int64_get(pc_obj, OBJ_F_LOCATION));
     }
 
-    if (map_by_type(MAP_TYPE_SHOPPING_MAP) == map_current_map()) {
+    if (!stru_5C36B0[mainmenu_ui_type][0]) {
+        // Pre-game Load Game (reached from the main menu, no game in
+        // session) — `player_get_local_pc_obj()` can return a stub PC
+        // here, so gate on the same "exit to game" menu-type flag the
+        // Options screen uses. No PC to look at → hide the lens entirely.
+        intgame_pc_lens_do(PC_LENS_MODE_NONE, NULL);
+    } else if (map_by_type(MAP_TYPE_SHOPPING_MAP) == map_current_map()) {
         intgame_pc_lens_do(PC_LENS_MODE_BLACKOUT, &pc_lens);
     } else {
         intgame_pc_lens_do(PC_LENS_MODE_PASSTHROUGH, &pc_lens);

--- a/src/ui/mainmenu_ui.c
+++ b/src/ui/mainmenu_ui.c
@@ -5128,13 +5128,19 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
                 // Use _unscale: msg coords are 800x600-local here but the
                 // lens check expects screen coords.
                 if (intgame_pc_lens_check_pt_unscale(msg->data.mouse.x, msg->data.mouse.y)) {
-                    if (stru_5C36B0[mainmenu_ui_type][0]) {
-                        if (!options_ui_load_module()) {
+                    // Mirror the Done button: commit module changes first
+                    // (bails if module load failed so the user stays on the
+                    // Options screen), then route through the same
+                    // stack-aware exit as ESC — full restore at the top of
+                    // the stack, pop to parent when stacked.
+                    if (options_ui_load_module()) {
+                        if (mainmenu_ui_num_windows <= 1
+                            && stru_5C36B0[mainmenu_ui_type][0]) {
                             sub_5412D0();
+                        } else {
+                            gsound_play_sfx(0, 1);
+                            mainmenu_ui_close(true);
                         }
-                    } else {
-                        gsound_play_sfx(0, 1);
-                        mainmenu_ui_close(true);
                     }
                     return true;
                 }

--- a/src/ui/mainmenu_ui.c
+++ b/src/ui/mainmenu_ui.c
@@ -1610,6 +1610,32 @@ void mainmenu_ui_start(MainMenuType type)
     }
 }
 
+// Open the main-menu UI directly to a specific window from in-game (like
+// the O shortcut does for Options). Reuses the MM_TYPE_OPTIONS flavor so
+// the menu has the single-press ESC return-to-game behavior wired up via
+// stru_5C36B0[MM_TYPE_OPTIONS][0]=true.
+void mainmenu_ui_start_at_window(MainMenuWindowType window_type)
+{
+    tig_art_id_t art_id;
+
+    if (mainmenu_ui_active) {
+        return;
+    }
+
+    mainmenu_ui_num_windows = 0;
+    intgame_hide();
+
+    tig_art_interface_id_create(0, 0, 0, 0, &art_id);
+    tig_mouse_cursor_set_art_id(art_id);
+    inven_ui_destroy();
+
+    mainmenu_ui_type = MM_TYPE_OPTIONS;
+    mainmenu_ui_window_type = window_type;
+    dword_5C4004 = false;
+    mainmenu_ui_open();
+    object_hover_obj_set(OBJ_HANDLE_NULL);
+}
+
 // 0x5412D0
 void sub_5412D0(void)
 {

--- a/src/ui/mainmenu_ui.c
+++ b/src/ui/mainmenu_ui.c
@@ -2,6 +2,8 @@
 
 #include <stdio.h>
 
+#include <tig/tig.h>
+
 #include "game/area.h"
 #include "game/background.h"
 #include "game/critter.h"
@@ -5098,23 +5100,41 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
         switch (msg->data.mouse.event) {
         case TIG_MESSAGE_MOUSE_LEFT_BUTTON_UP:
             // Click outside the menu's actual screen rect and outside both
-            // HUD strips dismisses any "in-game" overlay menu — same effect
-            // as ESC or clicking the PC lens. If the menu has a parent on
-            // the stack (e.g. Options reached from the pause menu), pop
-            // back to the parent; only fully exit to game when we're at
-            // the top of the stack.
-            if (stru_5C36B0[mainmenu_ui_type][0]
-                && mainmenu_ui_window_handle != TIG_WINDOW_HANDLE_INVALID) {
-                TigWindowData menu_wd;
-                if (tig_window_data(mainmenu_ui_window_handle, &menu_wd) == TIG_OK
-                    && intgame_should_dismiss_overlay_click(
-                        original_screen_x, original_screen_y, &menu_wd.rect)) {
-                    if (mainmenu_ui_num_windows <= 1) {
-                        sub_5412D0();
-                    } else {
-                        mainmenu_ui_close(true);
+            // HUD strips dismisses overlay menus — same effect as ESC or
+            // clicking the PC lens.
+            //
+            // Eligible for dismiss:
+            //   - Any in-game flavor menu (stru_5C36B0[type][0] == true)
+            //   - Main-menu Options / Load / Save: even though they aren't
+            //     "in-game" they still have the main menu as a parent on
+            //     the stack to pop back to.
+            //
+            // Exit behavior:
+            //   - In-game flavor at the top of the stack (num_windows <= 1):
+            //     full restore to game via sub_5412D0().
+            //   - Otherwise: pop to parent via mainmenu_ui_close(true).
+            //     This covers pause → Options → click-outside (back to
+            //     pause) and main-menu → Load → click-outside (back to
+            //     main menu) symmetrically.
+            {
+                bool in_game = stru_5C36B0[mainmenu_ui_type][0];
+                bool dismissible_window = in_game
+                    || mainmenu_ui_window_type == MM_WINDOW_OPTIONS
+                    || mainmenu_ui_window_type == MM_WINDOW_LOAD_GAME
+                    || mainmenu_ui_window_type == MM_WINDOW_SAVE_GAME;
+                if (dismissible_window
+                    && mainmenu_ui_window_handle != TIG_WINDOW_HANDLE_INVALID) {
+                    TigWindowData menu_wd;
+                    if (tig_window_data(mainmenu_ui_window_handle, &menu_wd) == TIG_OK
+                        && intgame_should_dismiss_overlay_click(
+                            original_screen_x, original_screen_y, &menu_wd.rect)) {
+                        if (in_game && mainmenu_ui_num_windows <= 1) {
+                            sub_5412D0();
+                        } else {
+                            mainmenu_ui_close(true);
+                        }
+                        return true;
                     }
-                    return true;
                 }
             }
             switch (mainmenu_ui_window_type) {
@@ -5130,12 +5150,21 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
                 if (intgame_pc_lens_check_pt_unscale(msg->data.mouse.x, msg->data.mouse.y)) {
                     // Mirror the Done button: commit module changes first
                     // (bails if module load failed so the user stays on the
-                    // Options screen), then route through the same
-                    // stack-aware exit as ESC — full restore at the top of
-                    // the stack, pop to parent when stacked.
+                    // Options screen). Then:
+                    //
+                    //   - In-game flavor (lens is PASSTHROUGH showing the
+                    //     game world): treat the lens tap as a shortcut
+                    //     straight back to game, regardless of how deep
+                    //     we are in the menu stack. This matches Save
+                    //     Game's PC-lens behavior and lets pause→Options
+                    //     → lens-tap return to game in one click instead
+                    //     of popping back to the pause menu first.
+                    //
+                    //   - Pre-game main-menu Options (lens is NONE, so
+                    //     this branch isn't normally reachable via a
+                    //     real click): fall back to pop-to-parent.
                     if (options_ui_load_module()) {
-                        if (mainmenu_ui_num_windows <= 1
-                            && stru_5C36B0[mainmenu_ui_type][0]) {
+                        if (stru_5C36B0[mainmenu_ui_type][0]) {
                             sub_5412D0();
                         } else {
                             gsound_play_sfx(0, 1);
@@ -5461,6 +5490,20 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
                 gsound_play_sfx(0, 1);
                 sub_5480C0(2);
                 return true;
+            }
+
+            // CE: Skip the auto-derived first-letter button hotkeys when Cmd /
+            // Ctrl is held. Cmd+Q on macOS fires both SDL_EVENT_QUIT and a
+            // KEY_DOWN for Q, and without this guard the latter activates the
+            // pause menu's "Quit Game" button (which does unload-to-main-menu)
+            // before the QUIT path reaches the confirm-and-exit-to-desktop
+            // handler. Letting TIG_MESSAGE_QUIT own all modifier-Q variants
+            // makes Cmd+Q behavior consistent everywhere (in-play, pause
+            // menu, main menu): always confirm + quit to desktop.
+            // Same defense for Cmd+S/L/O which already have explicit handlers
+            // in main.c — without this they'd race button hotkeys here too.
+            if (tig_kb_get_modifier(SDL_KMOD_CTRL | SDL_KMOD_GUI)) {
+                return false;
             }
 
             for (idx = 0; idx < window->num_buttons; idx++) {

--- a/src/ui/mainmenu_ui.c
+++ b/src/ui/mainmenu_ui.c
@@ -5036,6 +5036,8 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
     UiMessage ui_message;
     char str[MAX_STRING];
     int v2;
+    int original_screen_x = 0;
+    int original_screen_y = 0;
     TigMessage tmp_msg = *msg;
     msg = &tmp_msg;
 
@@ -5043,6 +5045,8 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
     // area.
     if (msg->type == TIG_MESSAGE_MOUSE) {
         TigRect rect = { 0, 0, 800, 600 };
+        original_screen_x = msg->data.mouse.x;
+        original_screen_y = msg->data.mouse.y;
         hrp_apply(&rect, GRAVITY_CENTER_HORIZONTAL | GRAVITY_CENTER_VERTICAL);
         msg->data.mouse.x -= rect.x;
         msg->data.mouse.y -= rect.y;
@@ -5078,6 +5082,22 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
 
         switch (msg->data.mouse.event) {
         case TIG_MESSAGE_MOUSE_LEFT_BUTTON_UP:
+            // Click outside the menu's actual screen rect and outside both
+            // HUD strips dismisses any "in-game" overlay menu — same effect
+            // as ESC or clicking the PC lens. Querying the live menu rect
+            // (rather than assuming 800x600) keeps this correct for partial
+            // menus too. At 800x600 native nothing falls outside both menu
+            // and HUD, so the original behavior is preserved.
+            if (stru_5C36B0[mainmenu_ui_type][0]
+                && mainmenu_ui_window_handle != TIG_WINDOW_HANDLE_INVALID) {
+                TigWindowData menu_wd;
+                if (tig_window_data(mainmenu_ui_window_handle, &menu_wd) == TIG_OK
+                    && intgame_should_dismiss_overlay_click(
+                           original_screen_x, original_screen_y, &menu_wd.rect)) {
+                    sub_5412D0();
+                    return true;
+                }
+            }
             switch (mainmenu_ui_window_type) {
             case MM_WINDOW_0:
             case MM_WINDOW_1:
@@ -5086,7 +5106,9 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
                 mainmenu_ui_open();
                 return true;
             case MM_WINDOW_OPTIONS:
-                if (intgame_pc_lens_check_pt(msg->data.mouse.x, msg->data.mouse.y)) {
+                // Use _unscale: msg coords are 800x600-local here but the
+                // lens check expects screen coords.
+                if (intgame_pc_lens_check_pt_unscale(msg->data.mouse.x, msg->data.mouse.y)) {
                     if (stru_5C36B0[mainmenu_ui_type][0]) {
                         if (!options_ui_load_module()) {
                             sub_5412D0();
@@ -5099,7 +5121,7 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
                 }
                 break;
             case MM_WINDOW_LOAD_GAME:
-                if (intgame_pc_lens_check_pt(msg->data.mouse.x, msg->data.mouse.y)) {
+                if (intgame_pc_lens_check_pt_unscale(msg->data.mouse.x, msg->data.mouse.y)) {
                     if (dword_64C450) {
                         sub_5412D0();
                     } else {
@@ -5109,7 +5131,7 @@ bool mainmenu_ui_message_filter(TigMessage* msg)
                 }
                 break;
             case MM_WINDOW_SAVE_GAME:
-                if (intgame_pc_lens_check_pt(msg->data.mouse.x, msg->data.mouse.y)) {
+                if (intgame_pc_lens_check_pt_unscale(msg->data.mouse.x, msg->data.mouse.y)) {
                     sub_5412D0();
                     return true;
                 }

--- a/src/ui/mainmenu_ui.h
+++ b/src/ui/mainmenu_ui.h
@@ -66,6 +66,7 @@ extern int64_t* dword_64C41C;
 bool mainmenu_ui_init(GameInitInfo* init_info);
 void mainmenu_ui_exit(void);
 void mainmenu_ui_start(MainMenuType type);
+void mainmenu_ui_start_at_window(MainMenuWindowType window_type);
 void sub_5412D0(void);
 bool mainmenu_ui_handle(void);
 bool mainmenu_ui_is_active(void);

--- a/src/ui/schematic_ui.c
+++ b/src/ui/schematic_ui.c
@@ -712,6 +712,18 @@ bool schematic_ui_message_filter(TigMessage* msg)
             return true;
         }
 
+        // Click outside the schematic window and outside both HUD strips
+        // dismisses the overlay (hi-res convenience).
+        if (msg->data.mouse.event == TIG_MESSAGE_MOUSE_LEFT_BUTTON_UP
+            && schematic_ui_window != TIG_WINDOW_HANDLE_INVALID) {
+            TigWindowData menu_wd;
+            if (tig_window_data(schematic_ui_window, &menu_wd) == TIG_OK
+                && intgame_should_dismiss_overlay_click(msg->data.mouse.x, msg->data.mouse.y, &menu_wd.rect)) {
+                schematic_ui_close();
+                return true;
+            }
+        }
+
         break;
     case TIG_MESSAGE_BUTTON:
         switch (msg->data.button.state) {

--- a/src/ui/wmap_ui.c
+++ b/src/ui/wmap_ui.c
@@ -1974,6 +1974,19 @@ bool wmap_ui_message_filter(TigMessage* msg)
                 return true;
             }
 
+            // Click outside the world map window and outside both HUD strips
+            // dismisses the overlay (hi-res convenience).
+            if (wmap_ui_window != TIG_WINDOW_HANDLE_INVALID) {
+                TigWindowData menu_wd;
+                int screen_x = msg->data.mouse.x + (hrp_iso_window_width_get() - 800) / 2;
+                int screen_y = msg->data.mouse.y + (hrp_iso_window_height_get() - 600) / 2;
+                if (tig_window_data(wmap_ui_window, &menu_wd) == TIG_OK
+                    && intgame_should_dismiss_overlay_click(screen_x, screen_y, &menu_wd.rect)) {
+                    wmap_ui_close();
+                    return true;
+                }
+            }
+
             return false;
         case TIG_MESSAGE_MOUSE_RIGHT_BUTTON_UP: {
             if (wmap_ui_state == WMAP_UI_STATE_EDITING) {

--- a/src/ui/written_ui.c
+++ b/src/ui/written_ui.c
@@ -681,6 +681,17 @@ bool written_ui_message_filter(TigMessage* msg)
             written_ui_close();
             return true;
         }
+        // Click outside the written-ui window and outside both HUD strips
+        // dismisses the overlay (hi-res convenience).
+        if (msg->data.mouse.event == TIG_MESSAGE_MOUSE_LEFT_BUTTON_UP
+            && written_ui_window != TIG_WINDOW_HANDLE_INVALID) {
+            TigWindowData menu_wd;
+            if (tig_window_data(written_ui_window, &menu_wd) == TIG_OK
+                && intgame_should_dismiss_overlay_click(msg->data.mouse.x, msg->data.mouse.y, &menu_wd.rect)) {
+                written_ui_close();
+                return true;
+            }
+        }
         break;
     case TIG_MESSAGE_BUTTON:
         if (msg->data.button.state == TIG_BUTTON_STATE_RELEASED) {


### PR DESCRIPTION
A bundle of small fixes and quality-of-life improvements.

## 1. Ghost button visuals on the bottom HUD (tig)

`tig_window_move` updates `win->frame` but leaves every child button's cached `btn->rect` stale (rects are stored in absolute screen coords at creation: `window.frame + button.local`). The next `tig_button_refresh_rect` then blits the button's art at `btn->rect - window.frame`, which with a stale rect against the moved frame writes to the wrong window-local offset — baking ghost button visuals into the parent window's pixel buffer.

Surfaces as duplicate Combat / Skills / Spells / Schematics buttons on the bottom HUD strip after `intgame_hide` / `intgame_show` shifts the strip between gravity-center and gravity-bottom. Only at resolutions > 800×600 (at 800×600 the move is a no-op); especially visible on macOS because the GL backend preserves backbuffer contents between presents.

Fix: add `tig_button_translate(handle, dx, dy)` and call it for every child button in `tig_window_move` so cached button rects follow the moved frame.

Bug:
<img width="3456" height="2168" alt="Screenshot 2026-05-18 at 6 40 33 PM" src="https://github.com/user-attachments/assets/1a8806db-53d5-45ef-af7f-5125e7a95559" />

Fixed:
<img width="3456" height="2168" alt="Screenshot 2026-05-18 at 7 24 24 PM" src="https://github.com/user-attachments/assets/e12857f5-9a68-4691-9792-b13053f585a6" />

## 2. Native cursor visibility on macOS (tig)

`SDL_HideCursor()` was being called unconditionally in `tig_video_init`, which on macOS hid the OS cursor even while the game cursor wasn't being rendered yet (splash / loading), causing conflicts. Removed the early hide — SDL hides/shows the cursor on its own based on the game's actual cursor state. Also macOS system events were allowing systemCursor to be forced back in instead of staying hidden.

## 3. ESC normalization for barter and main menu
Missed a few of these last time, but this should take care of rounding out ESC behaviors for the rest of the UI.
- `src/main.c`: removed `INTGAME_MODE_BARTER` from the ESC exclusion list so barter dismisses cleanly with ESC like any other modal.
- `src/ui/mainmenu_ui.c`: removed the ESC handler in `mainmenu_ui_message_filter` for `MM_WINDOW_MAINMENU` that was duplicating the global exit path and producing an extra SFX / state transition when ESC was pressed at the main menu.

## 4. One-press ESC return to game from in-game menus (and pop-to-parent when stacked)

The ESC handler in `mainmenu_ui_handle` called `mainmenu_ui_close(true)`, which only destroys the menu windows and pops the stack. For menu types launched from gameplay — in-play pause menu, in-play locked, and the in-game Options shortcut — `mainmenu_ui_start` first calls `intgame_hide`; the matching restore (`intgame_show`, etc.) lives in `sub_5412D0`, which is what the Done button on those screens calls. ESC bypassed it, forcing the user to press ESC three times to get back to a clean state.

ESC now differentiates by stack depth:

- **Top of stack** (no parent menu — O key, Cmd+S/L/O, ESC at the pause menu itself): route through `sub_5412D0` so the full restore runs and the user lands back in the world in one press.
- **Stacked** (e.g. pause menu → Options → ESC): pop back to the parent menu via the original `mainmenu_ui_close(true)` path.

The same logic powers the click-outside-window dismiss in fix # 6, so both ESC and outside-clicks are consistent.

## 5. In-game save / load shortcuts

In-game keyboard shortcuts following common OS conventions:

- **Cmd/Ctrl+S**       → quicksave (mirrors F7's autosave)
- **Cmd/Ctrl+Shift+S** → Save Game menu (mimics "Save As" familiar shortcut)
- **Cmd/Ctrl+L**       → quickload (mirrors F8's quickload)
- **Cmd/Ctrl+O**       → Load Game menu (mnemonic: "Open")

Either Cmd or Ctrl works (`SDL_KMOD_CTRL | SDL_KMOD_GUI`), so the platform-native convention (Cmd on macOS, Ctrl on Windows/Linux) is honored without per-platform code paths. F7 / F8 retain their existing bindings unchanged. Plain `O` still opens the Options menu — the `SDL_SCANCODE_O` handler branches on the Cmd/Ctrl modifier so the same key serves both Options (unmodified) and Load Game (modified). The in-game `S` sleep shortcut in `sub_54B5D0` was likewise gated to bail when Cmd/Ctrl is held so plain S still toggles sleep but Cmd+S falls through cleanly to quicksave.

New helper `mainmenu_ui_start_at_window(window_type)` mirrors `mainmenu_ui_start(MM_TYPE_OPTIONS)` but lets the caller pick the initial window; reusing the `MM_TYPE_OPTIONS` flavor means these shortcuts inherit the single-press ESC return-to-game behavior from fix # 4.

## 6. PC lens click + click-outside-window dismiss for overlay menus

Two related quality-of-life fixes for in-game overlay menus at hi-res:

**PC lens click on Save / Load / Options.** Clicking the PC lens to return to game worked in most overlays but did nothing on Save / Load / Options. `mainmenu_ui_message_filter` converts mouse coords from screen space to centered-800×600-local near the top, then was calling `intgame_pc_lens_check_pt` (which expects screen coords) with those converted local coords. Routed the three lens checks through the existing `intgame_pc_lens_check_pt_unscale` wrapper (same pattern wmap_ui and inven_ui already use).

**Click outside the menu dismisses the overlay.** At hi-res the menu doesn't fill the screen, so empty world area is visible around it. Clicking that area now dismisses the overlay — same effect as clicking the lens or pressing ESC. At 800×600 native nothing falls outside both menu and HUD strips, so original behavior is preserved.

New helper `intgame_should_dismiss_overlay_click(screen_x, screen_y, menu_rect)` returns true when the click is outside the supplied menu rect AND outside both iso-interface HUD strips (computed live from `intgame_interface_window_frames` + `hrp_apply`, so the 800-wide centered strips correctly leave their lateral empty space at hi-res as "outside HUD").

Wired into the message filters of:
- `mainmenu_ui` (save / load / options / pause)
- `inven_ui` (inventory, barter, loot, steal)
- `wmap_ui` (world map)
- `charedit_ui` (character sheet — skipped during creation modes)
- `schematic_ui` (crafting)
- `logbook_ui`
- `written_ui` (books)

Each queries its own window's actual screen rect via `tig_window_data` so partial menus dismiss correctly without hard-coding window sizes. The `mainmenu_ui` dismiss follows the same "pop to parent when stacked, full exit when top of stack" rule as ESC from fix # 4.

## 7. Pause-menu → Options no longer auto-dismisses

The `MM_WINDOW_OPTIONS` keyup handler unconditionally toggled the menu closed when `O` was released — correct for the in-game O shortcut (O acts as a toggle) but broken when entering Options via the pause menu's "O" hotkey button: the keydown opened Options, then the keyup raced into the toggle handler and immediately dismissed the menu. Gated the toggle-close on `mainmenu_ui_num_windows <= 1` so it only fires at the top of the menu stack.

## 8. Modal confirm dialogs no longer dismiss the menu behind them with ESC

`tig_window_modal_dialog_message_filter` handled ESC / Enter / OK / Cancel keys on keydown, closed the modal, and let the modal return its choice. The matching keyup was still queued behind the now-destroyed modal and flowed out to the underlying message loop — for `mainmenu_ui_handle` that was a fresh ESC keyup hitting its menu-close path, so cancelling a confirm dialog ("Are you sure you want to quit?" / "Delete this save?") with ESC also closed the menu that opened it.

Switch the modal's keyboard handling to keyup so the modal swallows both events before anything else sees them. Same behavior in practice — modal still dismisses with one key press — and the underlying menu no longer gets a phantom ESC.

## 9. Cancel / Done buttons follow stack-aware exit like ESC

`sub_5480C0` case 3 (Save/Load Cancel) and `mainmenu_ui_press_options` (Options Done) called `mainmenu_ui_close(true)` unconditionally — only pops the stack. When the menu was launched directly into the world (Cmd+Shift+S → Save, Cmd+O → Load, O → Options) the stack only had one entry, so the pop returned to `MM_WINDOW_0` with `mainmenu_ui_active=false` and `intgame_show()` never ran — same half-restored state ESC used to leave us in before fix # 4.

Apply the same stack-aware check as the ESC handler: when at the top of the stack (`mainmenu_ui_num_windows <= 1`) and the active menu type is an "exit to game" flavor, route through `sub_5412D0`. Otherwise keep the original close-back so menus reached from a parent still pop to the parent.

## 10. Hide PC lens on pre-game Options / Load Game

The PC lens widget shows a live view of the player character through a small rounded window — useful in-game, pointless on the pre-game menus where there's no player to look at. Previously:

- Pre-game Options drew the lens in `PC_LENS_MODE_BLACKOUT` (a black-filled circle in the lens frame) — visible but useless.
- Pre-game Load Game drew it in `PC_LENS_MODE_PASSTHROUGH` and showed whatever garbage `player_get_local_pc_obj()` happened to return at that point (a stub PC, last game's PC, etc.).

Both now hide the lens entirely (`PC_LENS_MODE_NONE`) when the active menu flavor is a main-menu type (`stru_5C36B0[mainmenu_ui_type][0] == false`). In-game entries (IN_PLAY / IN_PLAY_LOCKED / OPTIONS) still show the live world through the lens; the char-creation skills and shopping-map screens were already set up correctly