### PR TITLE
macOS: draw under the notch, aspect-snap resolution, migrate HighRes config, fix edge scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,17 +126,20 @@ Several configuration options are available as command-line switches (admittedly
 
 - `-geometry=1280x720`: Set window size (default is 800x600)
 
-Most options live in `arcanum.cfg` in the game directory as lowercase, space-separated keys, one per line:
+Most options live in `arcanum.cfg` in the game directory.
+
+On first launch, if `HighRes/config.ini` from the Unofficial Arcanum Patch is present, its keys (`Width`, `Height`, `Windowed`, `ShowFPS`, `ScrollFPS`, `ScrollDist`, `Logos`, `Intro` are migrated -- edit `arcanum.cfg` from then on:
 
 - `resolution width`, `resolution height`: rendered resolution (default 800x600)
 - `windowed`: `0` for fullscreen (default), `1` for windowed
 - `show fps`: `1` to overlay the frame rate
 - `scroll fps`, `scroll dist`: edge-scroll cadence and distance
 - `logos`, `intro`: `0` to skip the startup logos / intro cinematic
-- `macos ignore notch` (macOS only): `1` to draw under the camera notch via a borderless full-display window; `0` (default) keeps the standard SDL fullscreen which respects the menu bar / safe area
-- `aspect snap`: `1` (default) rewrites `resolution width` / `height` at startup to the nearest screen-aspect-matching pair so the rendered area fills the display instead of letterboxing; `0` uses the configured dimensions exactly
 
-On first launch, if `HighRes/config.ini` from the Unofficial Arcanum Patch is present, its keys (`Width`, `Height`, `Windowed`, `ShowFPS`, `ScrollFPS`, `ScrollDist`, `Logos`, `Intro`, and the PascalCase `IgnoreNotch` / `AspectSnap` if set) are imported into `arcanum.cfg`. The ini file is left in place but no longer read after migration -- edit `arcanum.cfg` from then on.
+- `aspect snap`: `1` (default) rewrites `resolution width` / `height` at startup to the nearest screen-aspect-matching pair so the rendered area fills the display instead of letterboxing; `0` uses the configured dimensions exactly. Setting to 800x600 (original resolution) will not be affected).
+
+- `macos ignore notch` (macOS only): `1` to draw under the camera notch via a borderless full-display window; `0` (default) keeps the standard SDL fullscreen which respects the  safe area.
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,17 @@ Several configuration options are available as command-line switches (admittedly
 
 - `-geometry=1280x720`: Set window size (default is 800x600)
 
-When `HighRes/config.ini` from the Unofficial Arcanum Patch is present in the game directory, Community Edition also imports `Width`, `Height`, `Windowed`, `ShowFPS`, `ScrollFPS`, `ScrollDist`, `Logos`, and `Intro` at startup.
+Most options live in `arcanum.cfg` in the game directory as lowercase, space-separated keys, one per line:
+
+- `resolution width`, `resolution height`: rendered resolution (default 800x600)
+- `windowed`: `0` for fullscreen (default), `1` for windowed
+- `show fps`: `1` to overlay the frame rate
+- `scroll fps`, `scroll dist`: edge-scroll cadence and distance
+- `logos`, `intro`: `0` to skip the startup logos / intro cinematic
+- `macos ignore notch` (macOS only): `1` to draw under the camera notch via a borderless full-display window; `0` (default) keeps the standard SDL fullscreen which respects the menu bar / safe area
+- `aspect snap`: `1` (default) rewrites `resolution width` / `height` at startup to the nearest screen-aspect-matching pair so the rendered area fills the display instead of letterboxing; `0` uses the configured dimensions exactly
+
+On first launch, if `HighRes/config.ini` from the Unofficial Arcanum Patch is present, its keys (`Width`, `Height`, `Windowed`, `ShowFPS`, `ScrollFPS`, `ScrollDist`, `Logos`, `Intro`, and the PascalCase `IgnoreNotch` / `AspectSnap` if set) are imported into `arcanum.cfg`. The ini file is left in place but no longer read after migration -- edit `arcanum.cfg` from then on.
 
 ## Contributing
 

--- a/first_party/tig/include/tig/types.h
+++ b/first_party/tig/include/tig/types.h
@@ -106,6 +106,11 @@ typedef unsigned int TigInitFlags;
 // the executable name).
 #define TIG_INITIALIZE_SET_WINDOW_NAME 0x4000u
 
+// macOS only: ignore the display's safe area so the window draws under the
+// menu bar / camera notch and covers the full panel. When this flag is not
+// set, the window respects the safe area and sits below the menu bar.
+#define TIG_INITIALIZE_IGNORE_NOTCH 0x8000u
+
 typedef int (*TigArtFilePathResolver)(tig_art_id_t art_id, char* path, size_t maxlen);
 typedef tig_art_id_t (*TigArtIdResetFunc)(tig_art_id_t art_id);
 typedef int (*TigSoundFilePathResolver)(int sound_id, char* path, size_t maxlen);

--- a/first_party/tig/include/tig/video.h
+++ b/first_party/tig/include/tig/video.h
@@ -139,6 +139,15 @@ int tig_video_buffer_tint(TigVideoBuffer* video_buffer, TigRect* rect, tig_color
 int tig_video_buffer_save_to_bmp(TigVideoBufferSaveToBmpInfo* save_info);
 int tig_video_buffer_load_from_bmp(const char* filename, TigVideoBuffer** video_buffer_ptr, unsigned int flags);
 
+#if defined(SDL_PLATFORM_MACOS) && SDL_PLATFORM_MACOS
+// Re-apply the macOS borderless-full-display window chrome (NSWindow level
+// above the menu bar, hide dock + menu bar). No-op unless the window was
+// created with TIG_INITIALIZE_IGNORE_NOTCH. Call on focus regain -- macOS
+// resets these on app deactivation, otherwise the menu bar and a window
+// title bar slide down at the top of the screen.
+void tig_video_macos_reapply_chrome(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/first_party/tig/src/message.c
+++ b/first_party/tig/src/message.c
@@ -117,6 +117,15 @@ void tig_message_ping(void)
         case SDL_EVENT_WINDOW_MOUSE_LEAVE:
             tig_set_active(false);
             break;
+#if defined(SDL_PLATFORM_MACOS) && SDL_PLATFORM_MACOS
+        case SDL_EVENT_WINDOW_FOCUS_GAINED:
+            // macOS resets the app's presentation options (hide menu bar /
+            // dock) and our NSWindow level when the app deactivates. Without
+            // this, after a cmd-tab the menu bar reappears at the top edge
+            // and drags a window title bar down with it.
+            tig_video_macos_reapply_chrome();
+            break;
+#endif
         case SDL_EVENT_MOUSE_MOTION:
             tig_mouse_set_position((int)event.motion.x, (int)event.motion.y);
             break;

--- a/first_party/tig/src/video.c
+++ b/first_party/tig/src/video.c
@@ -50,6 +50,16 @@ static bool sub_524830(void);
 static int tig_video_screenshot_make_internal(int key);
 static int tig_video_buffer_data_to_bmp(SDL_Surface* surface, TigRect* rect, const char* file_name);
 
+#if SDL_PLATFORM_MACOS
+// Tracks whether we created the window with the borderless-cover-full-display
+// path. macOS resets the app's presentation options and our NSWindow level on
+// app deactivation/reactivation, so we re-apply them on focus regain to keep
+// the menu bar (and its accompanying title-bar slide-down) from reappearing.
+static bool tig_video_macos_cover_full_display;
+
+static void tig_video_macos_apply_chrome(SDL_Window* window);
+#endif
+
 // 0x5BF3D8
 static int tig_video_screenshot_key = -1;
 
@@ -125,7 +135,58 @@ void tig_video_exit(void)
 {
     tig_video_window_destroy();
     tig_video_initialized = false;
+#if SDL_PLATFORM_MACOS
+    tig_video_macos_cover_full_display = false;
+#endif
 }
+
+#if SDL_PLATFORM_MACOS
+// Apply the borderless-cover-full-display NSWindow chrome (level above the
+// menu bar, no drop shadow, app-wide hide of dock+menu bar). Safe to call
+// repeatedly; we re-run this on focus regain because macOS resets both the
+// app's presentation options and the NSWindow level when the app deactivates,
+// which would otherwise let the menu bar (and its accompanying title-bar
+// slide-down) reappear at the top of the screen.
+static void tig_video_macos_apply_chrome(SDL_Window* window)
+{
+    if (window != NULL) {
+        SDL_PropertiesID window_props = SDL_GetWindowProperties(window);
+        void* nswindow = SDL_GetPointerProperty(window_props, SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, NULL);
+        if (nswindow != NULL) {
+            // NSMainMenuWindowLevel = 24; one above keeps us on top of the
+            // menu bar without entering NSPopUpMenuWindowLevel territory.
+            const long kAboveMenuBarLevel = 25;
+            ((void (*)(void*, SEL, long))objc_msgSend)(nswindow, sel_registerName("setLevel:"), kAboveMenuBarLevel);
+
+            // Borderless NSWindows still get the system drop shadow, which
+            // shows up as a faint 1px border around the edges of the screen
+            // for an edge-to-edge window.
+            ((void (*)(void*, SEL, signed char))objc_msgSend)(nswindow, sel_registerName("setHasShadow:"), 0);
+        }
+    }
+
+    // Hide the dock and menu bar app-wide. We use full HIDE (not auto-hide)
+    // so the menu bar can never reappear at the top edge -- auto-hide leaves
+    // a hot zone there where macOS will pop the menu bar back and slide a
+    // window title bar in alongside it.
+    id ns_app_class = (id)objc_getClass("NSApplication");
+    id ns_app = ((id (*)(id, SEL))objc_msgSend)(ns_app_class, sel_registerName("sharedApplication"));
+    if (ns_app != NULL) {
+        // NSApplicationPresentationHideDock     = 1 << 1
+        // NSApplicationPresentationHideMenuBar  = 1 << 3
+        const unsigned long kHideDockAndMenuBar = (1UL << 1) | (1UL << 3);
+        ((void (*)(id, SEL, unsigned long))objc_msgSend)(ns_app, sel_registerName("setPresentationOptions:"), kHideDockAndMenuBar);
+    }
+}
+
+void tig_video_macos_reapply_chrome(void)
+{
+    if (!tig_video_initialized || !tig_video_macos_cover_full_display) {
+        return;
+    }
+    tig_video_macos_apply_chrome(tig_video_state.window);
+}
+#endif
 
 int tig_video_window_get(SDL_Window** window_ptr)
 {
@@ -1324,41 +1385,8 @@ bool tig_video_window_create(TigInitInfo* init_info)
         SDL_SetWindowPosition(window, macos_display_bounds.x, macos_display_bounds.y);
         SDL_SetWindowSize(window, macos_display_bounds.w, macos_display_bounds.h);
 
-        // A regular borderless window still sits below the system menu bar
-        // on macOS, so the top pixels would be occluded by it (and the
-        // camera notch). Raise the NSWindow level above the menu bar so the
-        // window genuinely covers the full display. We poke Cocoa through
-        // the Objective-C runtime to avoid pulling AppKit into this C file.
-        SDL_PropertiesID window_props = SDL_GetWindowProperties(window);
-        void* nswindow = SDL_GetPointerProperty(window_props, SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, NULL);
-        if (nswindow != NULL) {
-            // NSMainMenuWindowLevel = 24; one above keeps us on top of the
-            // menu bar without entering NSPopUpMenuWindowLevel territory.
-            const long kAboveMenuBarLevel = 25;
-            ((void (*)(void*, SEL, long))objc_msgSend)(nswindow, sel_registerName("setLevel:"), kAboveMenuBarLevel);
-
-            // Borderless NSWindows still get the system drop shadow, which
-            // shows up as a faint 1px border around the edges of the screen
-            // for an edge-to-edge window. SDL's own fullscreen path disables
-            // this for the same reason; since we bypass that path we have
-            // to disable it ourselves.
-            ((void (*)(void*, SEL, signed char))objc_msgSend)(nswindow, sel_registerName("setHasShadow:"), 0);
-        }
-
-        // Hide the dock and menu bar app-wide. We use full HIDE (not
-        // auto-hide) so the menu bar can never reappear at the top edge --
-        // auto-hide leaves a hot zone there where macOS will pop the menu
-        // bar back, reclaim the cursor, and unhide the system cursor.
-        // NSApplicationPresentationHideMenuBar must be paired with
-        // NSApplicationPresentationHideDock per AppKit's contract.
-        id ns_app_class = (id)objc_getClass("NSApplication");
-        id ns_app = ((id (*)(id, SEL))objc_msgSend)(ns_app_class, sel_registerName("sharedApplication"));
-        if (ns_app != NULL) {
-            // NSApplicationPresentationHideDock     = 1 << 1
-            // NSApplicationPresentationHideMenuBar  = 1 << 3
-            const unsigned long kHideDockAndMenuBar = (1UL << 1) | (1UL << 3);
-            ((void (*)(id, SEL, unsigned long))objc_msgSend)(ns_app, sel_registerName("setPresentationOptions:"), kHideDockAndMenuBar);
-        }
+        tig_video_macos_cover_full_display = true;
+        tig_video_macos_apply_chrome(window);
     }
 #endif
 

--- a/first_party/tig/src/video.c
+++ b/first_party/tig/src/video.c
@@ -3,6 +3,11 @@
 #include <limits.h>
 #include <stdio.h>
 
+#if SDL_PLATFORM_MACOS
+#include <objc/message.h>
+#include <objc/runtime.h>
+#endif
+
 #include "tig/art.h"
 #include "tig/color.h"
 #include "tig/core.h"
@@ -1264,11 +1269,98 @@ bool tig_video_window_create(TigInitInfo* init_info)
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengles2,metal");
 #endif
 
+#if SDL_PLATFORM_MACOS
+    // On macOS, by default we let the window cover the full display, including
+    // the area under the camera notch. This avoids the window being clipped
+    // below the menu bar / notch on notched MacBooks. When the user clears
+    // `ignore notch`, the window is constrained to the display's usable bounds.
+    //
+    // We deliberately bypass SDL_WINDOW_FULLSCREEN here (which on macOS goes
+    // through Cocoa "Spaces" fullscreen via toggleFullScreen:). Spaces
+    // fullscreen still honors the system safe area on some macOS versions
+    // even with `NSPrefersDisplaySafeAreaCompatibilityMode` set in Info.plist
+    // (e.g. when a previous app bundle had the Get Info "Scale to fit below
+    // built-in camera" checkbox toggled). Instead, we manually create a
+    // borderless window sized to the full display and raise its NSWindow
+    // level above the menu bar so it genuinely covers the panel edge-to-edge.
+    bool macos_ignore_notch = (init_info->flags & TIG_INITIALIZE_IGNORE_NOTCH) != 0;
+    SDL_Rect macos_display_bounds;
+    if (macos_ignore_notch) {
+        SDL_GetDisplayBounds(SDL_GetPrimaryDisplay(), &macos_display_bounds);
+    } else {
+        SDL_GetDisplayUsableBounds(SDL_GetPrimaryDisplay(), &macos_display_bounds);
+    }
+
+    bool macos_cover_full_display = macos_ignore_notch;
+    if (macos_cover_full_display) {
+        // Drop SDL's Spaces-fullscreen path and use a borderless window we
+        // can position and level-raise ourselves.
+        flags &= ~SDL_WINDOW_FULLSCREEN;
+        flags |= SDL_WINDOW_BORDERLESS;
+        window_width = macos_display_bounds.w;
+        window_height = macos_display_bounds.h;
+    } else if ((init_info->flags & TIG_INITIALIZE_WINDOWED) != 0) {
+        // Clamp the requested windowed size to the available area so macOS
+        // does not silently shrink the window below the menu bar / notch.
+        if (window_width > macos_display_bounds.w) {
+            window_width = macos_display_bounds.w;
+        }
+        if (window_height > macos_display_bounds.h) {
+            window_height = macos_display_bounds.h;
+        }
+    }
+#endif
+
     SDL_Window* window;
     SDL_Renderer* renderer;
     if (!SDL_CreateWindowAndRenderer(name, window_width, window_height, flags, &window, &renderer)) {
         return false;
     }
+
+#if SDL_PLATFORM_MACOS
+    if (macos_cover_full_display) {
+        // Anchor the window to the top-left of the display so the borderless
+        // window actually covers the notch / menu bar area.
+        SDL_SetWindowPosition(window, macos_display_bounds.x, macos_display_bounds.y);
+        SDL_SetWindowSize(window, macos_display_bounds.w, macos_display_bounds.h);
+
+        // A regular borderless window still sits below the system menu bar
+        // on macOS, so the top pixels would be occluded by it (and the
+        // camera notch). Raise the NSWindow level above the menu bar so the
+        // window genuinely covers the full display. We poke Cocoa through
+        // the Objective-C runtime to avoid pulling AppKit into this C file.
+        SDL_PropertiesID window_props = SDL_GetWindowProperties(window);
+        void* nswindow = SDL_GetPointerProperty(window_props, SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, NULL);
+        if (nswindow != NULL) {
+            // NSMainMenuWindowLevel = 24; one above keeps us on top of the
+            // menu bar without entering NSPopUpMenuWindowLevel territory.
+            const long kAboveMenuBarLevel = 25;
+            ((void (*)(void*, SEL, long))objc_msgSend)(nswindow, sel_registerName("setLevel:"), kAboveMenuBarLevel);
+
+            // Borderless NSWindows still get the system drop shadow, which
+            // shows up as a faint 1px border around the edges of the screen
+            // for an edge-to-edge window. SDL's own fullscreen path disables
+            // this for the same reason; since we bypass that path we have
+            // to disable it ourselves.
+            ((void (*)(void*, SEL, signed char))objc_msgSend)(nswindow, sel_registerName("setHasShadow:"), 0);
+        }
+
+        // Hide the dock and menu bar app-wide. We use full HIDE (not
+        // auto-hide) so the menu bar can never reappear at the top edge --
+        // auto-hide leaves a hot zone there where macOS will pop the menu
+        // bar back, reclaim the cursor, and unhide the system cursor.
+        // NSApplicationPresentationHideMenuBar must be paired with
+        // NSApplicationPresentationHideDock per AppKit's contract.
+        id ns_app_class = (id)objc_getClass("NSApplication");
+        id ns_app = ((id (*)(id, SEL))objc_msgSend)(ns_app_class, sel_registerName("sharedApplication"));
+        if (ns_app != NULL) {
+            // NSApplicationPresentationHideDock     = 1 << 1
+            // NSApplicationPresentationHideMenuBar  = 1 << 3
+            const unsigned long kHideDockAndMenuBar = (1UL << 1) | (1UL << 3);
+            ((void (*)(id, SEL, unsigned long))objc_msgSend)(ns_app, sel_registerName("setPresentationOptions:"), kHideDockAndMenuBar);
+        }
+    }
+#endif
 
     SDL_PropertiesID renderer_props = SDL_GetRendererProperties(renderer);
     const char* driver_name = SDL_GetStringProperty(renderer_props, SDL_PROP_RENDERER_NAME_STRING, "");

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -30,5 +30,7 @@
     <string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
     <key>SDL_FILESYSTEM_BASE_DIR_TYPE</key>
     <string>parent</string>
+    <key>NSPrefersDisplaySafeAreaCompatibilityMode</key>
+    <false/>
 </dict>
 </plist>

--- a/src/game/highres_config.c
+++ b/src/game/highres_config.c
@@ -11,16 +11,16 @@
 
 // Keys in arcanum.cfg that mirror HighRes/config.ini. arcanum.cfg uses
 // lowercase keys with spaces; we match that convention for consistency.
-#define CFG_KEY_WIDTH       "resolution width"
-#define CFG_KEY_HEIGHT      "resolution height"
-#define CFG_KEY_WINDOWED    "windowed"
-#define CFG_KEY_SHOW_FPS    "show fps"
-#define CFG_KEY_SCROLL_FPS  "scroll fps"
+#define CFG_KEY_WIDTH "resolution width"
+#define CFG_KEY_HEIGHT "resolution height"
+#define CFG_KEY_WINDOWED "windowed"
+#define CFG_KEY_SHOW_FPS "show fps"
+#define CFG_KEY_SCROLL_FPS "scroll fps"
 #define CFG_KEY_SCROLL_DIST "scroll dist"
-#define CFG_KEY_LOGOS       "logos"
-#define CFG_KEY_INTRO       "intro"
+#define CFG_KEY_LOGOS "logos"
+#define CFG_KEY_INTRO "intro"
 #define CFG_KEY_IGNORE_NOTCH "macos ignore notch"
-#define CFG_KEY_ASPECT_SNAP  "aspect snap"
+#define CFG_KEY_ASPECT_SNAP "aspect snap"
 
 static void highres_config_reset(void);
 static void highres_config_parse_line(char* line);

--- a/src/game/highres_config.c
+++ b/src/game/highres_config.c
@@ -1,6 +1,7 @@
 #include "game/highres_config.h"
 
 #include <ctype.h>
+#include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,37 +9,292 @@
 
 #include <SDL3/SDL_stdinc.h>
 
+// Keys in arcanum.cfg that mirror HighRes/config.ini. arcanum.cfg uses
+// lowercase keys with spaces; we match that convention for consistency.
+#define CFG_KEY_WIDTH       "resolution width"
+#define CFG_KEY_HEIGHT      "resolution height"
+#define CFG_KEY_WINDOWED    "windowed"
+#define CFG_KEY_SHOW_FPS    "show fps"
+#define CFG_KEY_SCROLL_FPS  "scroll fps"
+#define CFG_KEY_SCROLL_DIST "scroll dist"
+#define CFG_KEY_LOGOS       "logos"
+#define CFG_KEY_INTRO       "intro"
+#define CFG_KEY_IGNORE_NOTCH "macos ignore notch"
+#define CFG_KEY_ASPECT_SNAP  "aspect snap"
+
 static void highres_config_reset(void);
 static void highres_config_parse_line(char* line);
 static void highres_config_trim(char** start_ptr, char** end_ptr);
 static bool highres_config_parse_int(const char* str, int* value_ptr);
+static bool highres_config_load_from_arcanum_cfg(void);
+static bool highres_config_load_from_highres_ini(void);
+static void highres_config_migrate_to_arcanum_cfg(void);
+static bool arcanum_cfg_read_int(const char* key, int* out);
+static bool arcanum_cfg_write_ints(const char* const* keys, const int* values, int count);
 
 static HighResConfig highres_config;
 
 void highres_config_load(void)
 {
-    FILE* stream;
-    char line[512];
-
     highres_config_reset();
 
-    stream = fopen("HighRes/config.ini", "rt");
-    if (stream == NULL) {
+    // Preferred source: arcanum.cfg. If any of the resolution keys are
+    // present we treat arcanum.cfg as authoritative and read everything we
+    // care about from there.
+    if (highres_config_load_from_arcanum_cfg()) {
+        highres_config.loaded = true;
         return;
     }
 
-    highres_config.loaded = true;
-
-    while (fgets(line, sizeof(line), stream) != NULL) {
-        highres_config_parse_line(line);
+    // First-launch fallback: pull values from the legacy HighRes/config.ini
+    // produced by the High Resolution Patch, then migrate them into
+    // arcanum.cfg so this file becomes the system of record going forward.
+    if (highres_config_load_from_highres_ini()) {
+        highres_config.loaded = true;
+        highres_config_migrate_to_arcanum_cfg();
     }
-
-    fclose(stream);
 }
 
 const HighResConfig* highres_config_get(void)
 {
     return &highres_config;
+}
+
+bool highres_config_save_resolution(int width, int height)
+{
+    if (width <= 0 || height <= 0) {
+        return false;
+    }
+
+    const char* keys[] = { CFG_KEY_WIDTH, CFG_KEY_HEIGHT };
+    const int values[] = { width, height };
+    if (!arcanum_cfg_write_ints(keys, values, 2)) {
+        return false;
+    }
+
+    highres_config.width = width;
+    highres_config.height = height;
+    return true;
+}
+
+static bool highres_config_load_from_arcanum_cfg(void)
+{
+    int width = 0;
+    bool found_width = arcanum_cfg_read_int(CFG_KEY_WIDTH, &width);
+    if (!found_width) {
+        return false;
+    }
+
+    int height = 0;
+    if (arcanum_cfg_read_int(CFG_KEY_HEIGHT, &height) && height >= 600) {
+        highres_config.height = height;
+    }
+    if (width >= 800) {
+        highres_config.width = width;
+    }
+
+    int value;
+    if (arcanum_cfg_read_int(CFG_KEY_WINDOWED, &value)) {
+        highres_config.windowed = value != 0;
+    }
+    if (arcanum_cfg_read_int(CFG_KEY_SHOW_FPS, &value)) {
+        highres_config.show_fps = value != 0;
+    }
+    if (arcanum_cfg_read_int(CFG_KEY_SCROLL_FPS, &value) && value > 0) {
+        highres_config.scroll_fps = value;
+    }
+    if (arcanum_cfg_read_int(CFG_KEY_SCROLL_DIST, &value) && value >= 0) {
+        highres_config.scroll_dist = value;
+    }
+    if (arcanum_cfg_read_int(CFG_KEY_LOGOS, &value)) {
+        highres_config.logos = value != 0;
+    }
+    if (arcanum_cfg_read_int(CFG_KEY_INTRO, &value)) {
+        highres_config.intro = value != 0;
+    }
+    if (arcanum_cfg_read_int(CFG_KEY_IGNORE_NOTCH, &value)) {
+        highres_config.ignore_notch = value != 0;
+    }
+    if (arcanum_cfg_read_int(CFG_KEY_ASPECT_SNAP, &value)) {
+        highres_config.aspect_snap = value != 0;
+    }
+    return true;
+}
+
+static bool highres_config_load_from_highres_ini(void)
+{
+    FILE* stream = fopen("HighRes/config.ini", "rt");
+    if (stream == NULL) {
+        return false;
+    }
+
+    char line[512];
+    while (fgets(line, sizeof(line), stream) != NULL) {
+        highres_config_parse_line(line);
+    }
+
+    fclose(stream);
+    return true;
+}
+
+static void highres_config_migrate_to_arcanum_cfg(void)
+{
+    const char* keys[] = {
+        CFG_KEY_WIDTH,
+        CFG_KEY_HEIGHT,
+        CFG_KEY_WINDOWED,
+        CFG_KEY_SHOW_FPS,
+        CFG_KEY_SCROLL_FPS,
+        CFG_KEY_SCROLL_DIST,
+        CFG_KEY_LOGOS,
+        CFG_KEY_INTRO,
+        CFG_KEY_IGNORE_NOTCH,
+        CFG_KEY_ASPECT_SNAP,
+    };
+    const int values[] = {
+        highres_config.width,
+        highres_config.height,
+        highres_config.windowed ? 1 : 0,
+        highres_config.show_fps ? 1 : 0,
+        highres_config.scroll_fps,
+        highres_config.scroll_dist,
+        highres_config.logos ? 1 : 0,
+        highres_config.intro ? 1 : 0,
+        highres_config.ignore_notch ? 1 : 0,
+        highres_config.aspect_snap ? 1 : 0,
+    };
+    arcanum_cfg_write_ints(keys, values, (int)(sizeof(keys) / sizeof(keys[0])));
+}
+
+static bool arcanum_cfg_read_int(const char* key, int* out)
+{
+    FILE* stream = fopen("arcanum.cfg", "rt");
+    if (stream == NULL) {
+        return false;
+    }
+
+    size_t key_len = strlen(key);
+    char line[512];
+    bool found = false;
+    while (fgets(line, sizeof(line), stream) != NULL) {
+        char* scan = line;
+        while (*scan == ' ' || *scan == '\t') {
+            scan++;
+        }
+        if (*scan == '\0' || *scan == '\r' || *scan == '\n' || (scan[0] == '/' && scan[1] == '/')) {
+            continue;
+        }
+        char* eq = strchr(scan, '=');
+        if (eq == NULL) {
+            continue;
+        }
+        // Trim trailing whitespace from the key portion.
+        char* key_end = eq;
+        while (key_end > scan && (key_end[-1] == ' ' || key_end[-1] == '\t')) {
+            key_end--;
+        }
+        if ((size_t)(key_end - scan) != key_len) {
+            continue;
+        }
+        if (SDL_strncasecmp(scan, key, key_len) != 0) {
+            continue;
+        }
+        if (highres_config_parse_int(eq + 1, out)) {
+            found = true;
+        }
+        break;
+    }
+
+    fclose(stream);
+    return found;
+}
+
+static bool arcanum_cfg_write_ints(const char* const* keys, const int* values, int count)
+{
+    if (count <= 0) {
+        return true;
+    }
+
+    // Read the existing file (if any) into memory so we can preserve every
+    // line we don't intend to touch.
+    FILE* in = fopen("arcanum.cfg", "rt");
+
+    FILE* out = fopen("arcanum.cfg.tmp", "wt");
+    if (out == NULL) {
+        if (in != NULL) {
+            fclose(in);
+        }
+        return false;
+    }
+
+    bool* written = (bool*)calloc((size_t)count, sizeof(bool));
+    if (written == NULL) {
+        if (in != NULL) {
+            fclose(in);
+        }
+        fclose(out);
+        remove("arcanum.cfg.tmp");
+        return false;
+    }
+
+    if (in != NULL) {
+        char line[512];
+        while (fgets(line, sizeof(line), in) != NULL) {
+            char* scan = line;
+            while (*scan == ' ' || *scan == '\t') {
+                scan++;
+            }
+            if (*scan == '\0' || *scan == '\r' || *scan == '\n' || (scan[0] == '/' && scan[1] == '/')) {
+                fputs(line, out);
+                continue;
+            }
+            char* eq = strchr(scan, '=');
+            if (eq == NULL) {
+                fputs(line, out);
+                continue;
+            }
+            char* key_end = eq;
+            while (key_end > scan && (key_end[-1] == ' ' || key_end[-1] == '\t')) {
+                key_end--;
+            }
+            size_t line_key_len = (size_t)(key_end - scan);
+
+            int matched = -1;
+            for (int i = 0; i < count; i++) {
+                size_t k = strlen(keys[i]);
+                if (k == line_key_len && SDL_strncasecmp(scan, keys[i], k) == 0) {
+                    matched = i;
+                    break;
+                }
+            }
+            if (matched >= 0 && !written[matched]) {
+                fprintf(out, "%s=%d\n", keys[matched], values[matched]);
+                written[matched] = true;
+            } else {
+                fputs(line, out);
+            }
+        }
+        fclose(in);
+    }
+
+    // Append any keys that weren't already present.
+    for (int i = 0; i < count; i++) {
+        if (!written[i]) {
+            fprintf(out, "%s=%d\n", keys[i], values[i]);
+        }
+    }
+
+    free(written);
+    fclose(out);
+
+    if (remove("arcanum.cfg") != 0 && errno != ENOENT) {
+        remove("arcanum.cfg.tmp");
+        return false;
+    }
+    if (rename("arcanum.cfg.tmp", "arcanum.cfg") != 0) {
+        return false;
+    }
+    return true;
 }
 
 void highres_config_reset(void)
@@ -52,6 +308,8 @@ void highres_config_reset(void)
     highres_config.scroll_dist = 10;
     highres_config.logos = true;
     highres_config.intro = true;
+    highres_config.ignore_notch = false;
+    highres_config.aspect_snap = true;
 }
 
 void highres_config_parse_line(char* line)
@@ -122,6 +380,10 @@ void highres_config_parse_line(char* line)
         highres_config.logos = value != 0;
     } else if (SDL_strcasecmp(key_start, "Intro") == 0) {
         highres_config.intro = value != 0;
+    } else if (SDL_strcasecmp(key_start, "IgnoreNotch") == 0) {
+        highres_config.ignore_notch = value != 0;
+    } else if (SDL_strcasecmp(key_start, "AspectSnap") == 0) {
+        highres_config.aspect_snap = value != 0;
     }
 }
 

--- a/src/game/highres_config.h
+++ b/src/game/highres_config.h
@@ -13,9 +13,27 @@ typedef struct HighResConfig {
     int scroll_dist;
     bool logos;
     bool intro;
+    // macOS-only: when true, the game ignores the system safe area on
+    // notched MacBooks, drawing under the camera notch / menu bar. When
+    // false (the default), the game respects the safe area (rendered area
+    // sits below the notch and menu bar). UI elements are calibrated for
+    // safe-area-respecting layout, so opting in is the user's call.
+    bool ignore_notch;
+    // Cross-platform: when true (the default), the game snaps the user's
+    // configured (Width, Height) to the screen-aspect-matching pair
+    // nearest their values whenever the window will fill the screen. This
+    // eliminates letterbox bars without changing the user's intent by
+    // more than a few pixels. Set to false to use the configured
+    // dimensions exactly (letterbox bars may appear).
+    bool aspect_snap;
 } HighResConfig;
 
 void highres_config_load(void);
 const HighResConfig* highres_config_get(void);
+
+// Rewrites Width/Height in HighRes/config.ini to the given values, leaving
+// all other lines (comments, spacing, other keys) intact. Updates the
+// in-memory config too. Returns true on success.
+bool highres_config_save_resolution(int width, int height);
 
 #endif /* GAME_HIGHRES_CONFIG_H_ */

--- a/src/main.c
+++ b/src/main.c
@@ -813,16 +813,60 @@ void handle_mouse_scroll(void)
     int height;
     int tolerance;
 
+    width = hrp_iso_window_width_get();
+    height = hrp_iso_window_height_get();
+    tolerance = 8;
+
     if (!tig_get_active()) {
+        // The cursor has left the window. When the window is constrained to
+        // the display's safe area (e.g. macOS with menu bar / camera notch
+        // above), rolling past the top of the window would otherwise stop
+        // edge scrolling because the cursor is no longer over the window.
+        // Recover the global cursor position and, if it sits above the top
+        // of the window (within its horizontal span), keep scrolling up.
+        SDL_Window* window = NULL;
+        if (tig_video_window_get(&window) == TIG_OK && window != NULL) {
+            float gx_f = 0.0f;
+            float gy_f = 0.0f;
+            int wx = 0;
+            int wy = 0;
+            int ww = 0;
+            int wh = 0;
+
+            SDL_GetGlobalMouseState(&gx_f, &gy_f);
+            SDL_GetWindowPosition(window, &wx, &wy);
+            SDL_GetWindowSize(window, &ww, &wh);
+
+            int rel_x = (int)gx_f - wx;
+            int rel_y = (int)gy_f - wy;
+
+            if (rel_y < tolerance && rel_x >= 0 && rel_x < ww) {
+                // Match the in-window corner detection: only a `tolerance`
+                // px sliver in each top corner counts as the diagonal
+                // direction, the rest of the top edge is pure UP. Using
+                // quarter-width zones here caused unintended horizontal
+                // scrolling because the game's edge logic is calibrated
+                // around 800x600 / a small absolute pixel tolerance, not a
+                // fraction of the window width.
+                if (rel_x < tolerance) {
+                    scroll_start(SCROLL_DIRECTION_UP_LEFT);
+                } else if (rel_x >= ww - tolerance) {
+                    scroll_start(SCROLL_DIRECTION_UP_RIGHT);
+                } else {
+                    scroll_start(SCROLL_DIRECTION_UP);
+                }
+                return;
+            }
+        }
         scroll_stop();
         return;
     }
 
     tig_mouse_get_state(&mouse_state);
-    width = hrp_iso_window_width_get();
-    height = hrp_iso_window_height_get();
-    tolerance = 8;
 
+    // Treat negative coordinates (cursor above/left of the logical content
+    // rect after letterboxing) the same as the top/left edge so edge
+    // scrolling still triggers when the cursor overshoots the bounds.
     if (mouse_state.x < tolerance) {
         if (mouse_state.y < tolerance) {
             scroll_start(SCROLL_DIRECTION_UP_LEFT);

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <SDL3/SDL_main.h>
 
@@ -89,6 +90,111 @@ int main(int argc, char** argv)
 
     highres_config_load();
     highres_config = highres_config_get();
+
+    // SDL_GetDisplay*Bounds below requires the video subsystem to be live.
+    // tig_init does this for us later, but the snap needs the display
+    // metrics now so it can rewrite arcanum.cfg before tig reads the
+    // resolution off of highres_config. SDL_Init is reference-counted, so
+    // calling it here is safe even though tig_init will call it again.
+    SDL_InitSubSystem(SDL_INIT_VIDEO);
+
+    // Letterboxing the configured logical resolution against the screen's
+    // aspect ratio leaves visible bars whenever the game is going to fill
+    // the screen. Snap to the aspect-matching pair nearest to the user's
+    // configured (width, height) and persist the result to arcanum.cfg.
+    //
+    // The snap runs whenever the game will end up at full-screen size:
+    //   * Any platform, Windowed = 0 -> fullscreen, snap to display bounds
+    //   * macOS, ignore notch = 1 -> we cover the full panel ourselves,
+    //     snap to full display bounds regardless of the windowed flag
+    //   * macOS, ignore notch = 0, Windowed = 0 -> SDL fullscreen still
+    //     extends under the notch (NSPrefersDisplaySafeAreaCompatibilityMode
+    //     is false in Info.plist), so snap against full display bounds too
+    // The user's explicit (small) windowed size is otherwise preserved.
+    //
+    // We consider two candidates: hold the configured width and recompute
+    // height, or hold the configured height and recompute width. The one
+    // that moves fewer pixels from the user's setting wins; ties go to the
+    // candidate that preserves width (UI layout is more width-sensitive).
+    bool should_snap_aspect = highres_config->aspect_snap && !highres_config->windowed;
+#if SDL_PLATFORM_MACOS
+    if (highres_config->aspect_snap && highres_config->ignore_notch) {
+        should_snap_aspect = true;
+    }
+#endif
+    if (should_snap_aspect) {
+        SDL_Rect display_bounds;
+        bool got_bounds = SDL_GetDisplayBounds(SDL_GetPrimaryDisplay(), &display_bounds);
+#if SDL_PLATFORM_MACOS
+        // When the game respects the macOS safe area, the rendered viewport
+        // sits inside the usable bounds (below the menu bar / camera notch).
+        // We only want to do that on Macs that actually have a notch -- on
+        // a regular display (or a third-party monitor) the usable bounds
+        // also trim the menu bar, but the rendered area in fullscreen
+        // covers the whole panel (menu bar auto-hides), so snapping
+        // against usable bounds there would just introduce a 24 px
+        // mismatch.
+        //
+        // Detect a notch by the menu bar height: notched MacBooks have a
+        // menu bar in the 37-44 pt range, regular Macs sit around 24. The
+        // delta between full and usable bounds is the menu bar height
+        // (no dock subtraction at the top), so a threshold of 30 cleanly
+        // separates the two.
+        if (!highres_config->ignore_notch && got_bounds) {
+            SDL_Rect usable_bounds;
+            if (SDL_GetDisplayUsableBounds(SDL_GetPrimaryDisplay(), &usable_bounds)
+                && (display_bounds.h - usable_bounds.h) > 30) {
+                display_bounds = usable_bounds;
+            }
+        }
+#endif
+        if (got_bounds
+            && display_bounds.w > 0
+            && display_bounds.h > 0
+            && highres_config->width >= 800
+            && highres_config->height >= 600) {
+            double display_aspect = (double)display_bounds.w / (double)display_bounds.h;
+            double config_aspect = (double)highres_config->width / (double)highres_config->height;
+
+            // Only act when the user's aspect actually differs from the
+            // display's; sub-pixel differences round to the same snap.
+            double aspect_delta = config_aspect - display_aspect;
+            if (aspect_delta < 0) {
+                aspect_delta = -aspect_delta;
+            }
+            if (aspect_delta > 1e-4) {
+                // Candidate A: keep width, recompute height.
+                int width_a = highres_config->width;
+                int height_a = (int)((double)width_a / display_aspect + 0.5);
+                if ((height_a & 1) != 0) {
+                    height_a += 1;
+                }
+
+                // Candidate B: keep height, recompute width.
+                int height_b = highres_config->height;
+                int width_b = (int)((double)height_b * display_aspect + 0.5);
+                if ((width_b & 1) != 0) {
+                    width_b += 1;
+                }
+
+                int delta_a = abs(height_a - highres_config->height);
+                int delta_b = abs(width_b - highres_config->width);
+
+                int snapped_w = width_a;
+                int snapped_h = height_a;
+                if (delta_b < delta_a && width_b >= 800 && height_b >= 600) {
+                    snapped_w = width_b;
+                    snapped_h = height_b;
+                }
+
+                if (snapped_w >= 800
+                    && snapped_h >= 600
+                    && (snapped_w != highres_config->width || snapped_h != highres_config->height)) {
+                    highres_config_save_resolution(snapped_w, snapped_h);
+                }
+            }
+        }
+    }
 
     init_info.texture_width = 1024;
     init_info.texture_height = 1024;

--- a/src/main.c
+++ b/src/main.c
@@ -185,6 +185,10 @@ int main(int argc, char** argv)
         init_info.flags |= TIG_INITIALIZE_WINDOWED;
     }
 
+    if (highres_config->ignore_notch) {
+        init_info.flags |= TIG_INITIALIZE_IGNORE_NOTCH;
+    }
+
     // NOTE: The `window` switch is borrowed from ToEE.
     if (strstr(lpCmdLine, "-window") != NULL) {
         init_info.flags |= TIG_INITIALIZE_WINDOWED;


### PR DESCRIPTION
Closes #100.

Five small commits to make Arcanum behave on modern macOS — especially notched MacBooks. All macOS-specific code is `#if SDL_PLATFORM_MACOS`-guarded; other platforms unchanged.

- Revision to previous High Res Patch Support PR #105 — Now migrates `HighRes/config.ini` → `arcanum.cfg` when present (legacy keys still read on first launch), clean separation for the future - and works indepependently without the patch .ini.
- Optional borderless full-display window that draws under the notch (`macos ignore notch=1`).
- Aspect-snap the configured resolution to the screen's aspect at startup so it fills instead of letterboxing (`aspect snap=1`, skipped at the configured-minimum 800×600).
- Edge-scroll fallback via `SDL_GetGlobalMouseState` so up-edge scroll keeps firing when the cursor leaves the window.
- Re-apply the borderless chrome on `SDL_EVENT_WINDOW_FOCUS_GAINED` — macOS resets presentation options on cmd-tab, which would otherwise let the menu bar (and a window title bar) slide back in.

### New cfg keys

| Key | Default | Effect |
|---|---|---|
| `macos ignore notch` | `0` | `1` = borderless full-display window above the menu bar. `0` = standard SDL fullscreen. |
| `aspect snap` | `1` | `1` = rewrite `resolution width`/`height` to nearest screen-aspect pair. `0` = use configured dims exactly. |