### PR TITLE
fix(quest): populate `dumb_description` with entries from `gamequestlogdumb.mes`

### DIFF
--- a/src/game/quest.c
+++ b/src/game/quest.c
@@ -165,7 +165,7 @@ bool quest_mod_load(void)
         if (mes_load("mes\\gamequestlogdumb.mes", &quest_log_dumb_mes_file)) {
             for (num = 1000; num < 2000; num++) {
                 mes_file_entry.num = num;
-                if (mes_search(quest_log_mes_file, &mes_file_entry)) {
+                if (mes_search(quest_log_dumb_mes_file, &mes_file_entry)) {
                     quests[quest_num_to_idx(num)].dumb_description = mes_file_entry.str;
                 }
             }


### PR DESCRIPTION
A trivial fix for a copy-paste-like bug in `quest.c` module: logbook shows normal quest descriptions when playing "dumb" character.

Before the fix (Half-Ogre, "Raised in the Pits" background, 1 INT total):
<img width="358" height="246" alt="quest-log" src="https://github.com/user-attachments/assets/a458eab0-6e56-4015-baa5-4798838fa3a3" />

Fixed version:
<img width="307" height="213" alt="quest-log-fixed" src="https://github.com/user-attachments/assets/ce04e4bc-e96c-412b-870c-b517acd27353" />


