### PR TITLE
fix(macos): fall back to launch dir when base path lacks game data

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -76,7 +76,21 @@ int main(int argc, char** argv)
     char msg[80];
 
 #if SDL_PLATFORM_MACOS
-    chdir(SDL_GetBasePath());
+    // chdir to the data folder (next to the .app), falling back to the launch
+    // directory if the base path does not point there.
+    {
+        char launch_cwd[TIG_MAX_PATH];
+        const char* base = SDL_GetBasePath();
+        bool have_launch_cwd = getcwd(launch_cwd, sizeof(launch_cwd)) != NULL;
+
+        if (base != NULL) {
+            chdir(base);
+        }
+
+        if (access("tig.dat", F_OK) != 0 && have_launch_cwd) {
+            chdir(launch_cwd);
+        }
+    }
 #elif SDL_PLATFORM_IOS
     chdir(SDL_GetUserFolder(SDL_FOLDER_DOCUMENTS));
 #elif SDL_PLATFORM_ANDROID


### PR DESCRIPTION
## Problem

On macOS the game fails to start: the window never appears, and running the binary directly prints:

```
      TIG File: Error - Invalid path "tig.dat"
      Error initializing TIG: file
```

Reproduced on Apple Silicon with a clean GOG install.
  
## Root cause

`main()` does `chdir(SDL_GetBasePath())` on macOS. The data assets live in the  folder that *contains* the .app bundle, which only works if SDL returns the bundle's parent. When that path resolves elsewhere (e.g. Contents/Resources),  the chdir lands in the wrong directory and tig.dat is never found. The chdir  also overrode the directory the user launched from.

## Fix

Remember the launch directory, chdir to the base path, and fall back to the launch directory if `tig.dat` is not found there. Also avoids `chdir(NULL)`.

## Testing
  
Built for macOS arm64; clean GOG data now loads and the game starts from both Finder (`open`) and a direct terminal launch.

Fixes #145 
