### PR TITLE
fix(engine): script cache leaking

### DIFF
--- a/src/game/script.c
+++ b/src/game/script.c
@@ -3369,12 +3369,6 @@ ScriptFile* script_lock(int script_id)
     if (script_cache_entries[cache_entry_id].script_id == script_id) {
         script_cache_entries[cache_entry_id].ref_count++;
         script_cache_entries[cache_entry_id].datetime = sub_45A7C0();
-        // DIAG (temporary): observe the ref_count increment on lock.
-        char diag_name[TIG_MAX_PATH];
-        if (!script_name_build_scr_name(script_id, diag_name, sizeof(diag_name))) {
-            diag_name[0] = '\0';
-        }
-        tig_debug_printf("[refcount DIAG] LOCK   %-24s (id=%d) ref=%d\n", diag_name, script_id, script_cache_entries[cache_entry_id].ref_count);
         return script_cache_entries[cache_entry_id].file;
     }
 
@@ -3385,12 +3379,6 @@ ScriptFile* script_lock(int script_id)
     if (cache_add(cache_entry_id, script_id)) {
         script_cache_entries[cache_entry_id].ref_count++;
         script_cache_entries[cache_entry_id].datetime = sub_45A7C0();
-        // DIAG (temporary): observe the ref_count increment on lock.
-        char diag_name[TIG_MAX_PATH];
-        if (!script_name_build_scr_name(script_id, diag_name, sizeof(diag_name))) {
-            diag_name[0] = '\0';
-        }
-        tig_debug_printf("[refcount DIAG] LOCK   %-24s (id=%d) ref=%d\n", diag_name, script_id, script_cache_entries[cache_entry_id].ref_count);
         return script_cache_entries[cache_entry_id].file;
     }
 
@@ -3402,26 +3390,12 @@ void script_unlock(int script_id)
 {
     int cache_entry_id;
 
-    // FIX: guard was inverted relative to script_lock; in gameplay it made
-    // unlock a no-op so ref_count only ever grew until the cache filled and
-    // cache_find() exit()ed. Match script_lock so unlock decrements in play.
     if (script_editor) {
         return;
     }
 
     cache_entry_id = cache_find(script_id);
     script_cache_entries[cache_entry_id].ref_count--;
-    // DIAG (temporary): observe the ref_count decrement on unlock. In the buggy
-    // build this line is unreachable (the guard above returns first), so NO
-    // UNLOCK lines appear — proof that unlock never decrements in gameplay. When
-    // ref hits 0 the slot only becomes *evictable*; it is not removed yet.
-    char diag_name[TIG_MAX_PATH];
-    if (!script_name_build_scr_name(script_id, diag_name, sizeof(diag_name))) {
-        diag_name[0] = '\0';
-    }
-    tig_debug_printf("[refcount DIAG] UNLOCK %-24s (id=%d) ref=%d%s\n", diag_name, script_id,
-        script_cache_entries[cache_entry_id].ref_count,
-        script_cache_entries[cache_entry_id].ref_count == 0 ? "  (evictable)" : "");
 }
 
 // 0x44C480
@@ -3500,14 +3474,6 @@ bool cache_add(int cache_entry_id, int script_id)
 void cache_remove(int cache_entry_id)
 {
     if (script_cache_entries[cache_entry_id].script_id) {
-        // DIAG (temporary): the script is actually removed from the cache here.
-        // This happens LATER than ref reaching 0 — only when a slot must be
-        // freed for a new script (cache full). ref==0 alone does not remove it.
-        char diag_name[TIG_MAX_PATH];
-        if (!script_name_build_scr_name(script_cache_entries[cache_entry_id].script_id, diag_name, sizeof(diag_name))) {
-            diag_name[0] = '\0';
-        }
-        tig_debug_printf("[refcount DIAG] EVICT  %-24s (id=%d, removed from cache)\n", diag_name, script_cache_entries[cache_entry_id].script_id);
         script_file_destroy(script_cache_entries[cache_entry_id].file);
         script_cache_entries[cache_entry_id].script_id = 0;
     }

--- a/src/game/script.c
+++ b/src/game/script.c
@@ -3402,7 +3402,10 @@ void script_unlock(int script_id)
 {
     int cache_entry_id;
 
-    if (!script_editor) {
+    // FIX: guard was inverted relative to script_lock; in gameplay it made
+    // unlock a no-op so ref_count only ever grew until the cache filled and
+    // cache_find() exit()ed. Match script_lock so unlock decrements in play.
+    if (script_editor) {
         return;
     }
 

--- a/src/game/script.c
+++ b/src/game/script.c
@@ -3369,6 +3369,12 @@ ScriptFile* script_lock(int script_id)
     if (script_cache_entries[cache_entry_id].script_id == script_id) {
         script_cache_entries[cache_entry_id].ref_count++;
         script_cache_entries[cache_entry_id].datetime = sub_45A7C0();
+        // DIAG (temporary): observe the ref_count increment on lock.
+        char diag_name[TIG_MAX_PATH];
+        if (!script_name_build_scr_name(script_id, diag_name, sizeof(diag_name))) {
+            diag_name[0] = '\0';
+        }
+        tig_debug_printf("[refcount DIAG] LOCK   %-24s (id=%d) ref=%d\n", diag_name, script_id, script_cache_entries[cache_entry_id].ref_count);
         return script_cache_entries[cache_entry_id].file;
     }
 
@@ -3379,6 +3385,12 @@ ScriptFile* script_lock(int script_id)
     if (cache_add(cache_entry_id, script_id)) {
         script_cache_entries[cache_entry_id].ref_count++;
         script_cache_entries[cache_entry_id].datetime = sub_45A7C0();
+        // DIAG (temporary): observe the ref_count increment on lock.
+        char diag_name[TIG_MAX_PATH];
+        if (!script_name_build_scr_name(script_id, diag_name, sizeof(diag_name))) {
+            diag_name[0] = '\0';
+        }
+        tig_debug_printf("[refcount DIAG] LOCK   %-24s (id=%d) ref=%d\n", diag_name, script_id, script_cache_entries[cache_entry_id].ref_count);
         return script_cache_entries[cache_entry_id].file;
     }
 
@@ -3396,6 +3408,17 @@ void script_unlock(int script_id)
 
     cache_entry_id = cache_find(script_id);
     script_cache_entries[cache_entry_id].ref_count--;
+    // DIAG (temporary): observe the ref_count decrement on unlock. In the buggy
+    // build this line is unreachable (the guard above returns first), so NO
+    // UNLOCK lines appear — proof that unlock never decrements in gameplay. When
+    // ref hits 0 the slot only becomes *evictable*; it is not removed yet.
+    char diag_name[TIG_MAX_PATH];
+    if (!script_name_build_scr_name(script_id, diag_name, sizeof(diag_name))) {
+        diag_name[0] = '\0';
+    }
+    tig_debug_printf("[refcount DIAG] UNLOCK %-24s (id=%d) ref=%d%s\n", diag_name, script_id,
+        script_cache_entries[cache_entry_id].ref_count,
+        script_cache_entries[cache_entry_id].ref_count == 0 ? "  (evictable)" : "");
 }
 
 // 0x44C480
@@ -3474,6 +3497,14 @@ bool cache_add(int cache_entry_id, int script_id)
 void cache_remove(int cache_entry_id)
 {
     if (script_cache_entries[cache_entry_id].script_id) {
+        // DIAG (temporary): the script is actually removed from the cache here.
+        // This happens LATER than ref reaching 0 — only when a slot must be
+        // freed for a new script (cache full). ref==0 alone does not remove it.
+        char diag_name[TIG_MAX_PATH];
+        if (!script_name_build_scr_name(script_cache_entries[cache_entry_id].script_id, diag_name, sizeof(diag_name))) {
+            diag_name[0] = '\0';
+        }
+        tig_debug_printf("[refcount DIAG] EVICT  %-24s (id=%d, removed from cache)\n", diag_name, script_cache_entries[cache_entry_id].script_id);
         script_file_destroy(script_cache_entries[cache_entry_id].file);
         script_cache_entries[cache_entry_id].script_id = 0;
     }


### PR DESCRIPTION
## Problem

 On a long continuous session (~8–10h) the game exits mid-play. Running from a terminal, the log ends with:

```
cache_find: Error: failed to find cache item!
```

Reproduced on Apple Silicon with a clean GOG install.

## Root cause        

script_unlock's guard is inverted relative to script_lock. script_lock early-returns only in the editor, but script_unlock early-returns during normal gameplay — so in playmit never runs. Every script_lock then increments ref_count while the paired script_unlock is a no-op, so each executed script keeps its cache slot pinned. Once all MAX_CACHE_ENTRIES (100) slots have ref_count > 0, cache_find finds nothing to evict and calls exit()

In my custom log (while testing fix) i see only locks, example:

```
2026-07-02 01:40:33.580 arcanum-ce[76840:1685302] [refcount DIAG] LOCK   scr\09100moneylimit_hb.scr (id=9100) ref=1141
2026-07-02 01:40:33.580 arcanum-ce[76840:1685302] [refcount DIAG] LOCK   scr\09100moneylimit_hb.scr (id=9100) ref=1142
2026-07-02 01:40:33.580 arcanum-ce[76840:1685302] [refcount DIAG] LOCK   scr\09100moneylimit_hb.scr (id=9100) ref=1143
2026-07-02 01:40:33.681 arcanum-ce[76840:1685302] [refcount DIAG] LOCK   scr\09100moneylimit_hb.scr (id=9100) ref=1144
2026-07-02 01:40:33.681 arcanum-ce[76840:1685302] [refcount DIAG] LOCK   scr\09100moneylimit_hb.scr (id=9100) ref=1145
2026-07-02 01:40:33.681 arcanum-ce[76840:1685302] [refcount DIAG] LOCK   scr\09100moneylimit_hb.scr (id=9100) ref=1146
...
```

## Fix

Flip the guard so script_unlock decrements ref_count during gameplay (and stays a no-op in the editor, matching script_lock).

In my custom log (while testing fix) now i see locks and unlocks too, example:

```
2026-07-02 01:56:39.132 arcanum-ce[77357:1700621] [refcount DIAG] LOCK   scr\09100moneylimit_hb.scr (id=9100) ref=1
2026-07-02 01:56:39.132 arcanum-ce[77357:1700621] [refcount DIAG] UNLOCK scr\09100moneylimit_hb.scr (id=9100) ref=0  (evictable)
2026-07-02 01:56:39.189 arcanum-ce[77357:1700621] [refcount DIAG] LOCK   scr\02295kendrick_wales_dead_hb.scr (id=2295) ref=1
2026-07-02 01:56:39.189 arcanum-ce[77357:1700621] [refcount DIAG] UNLOCK scr\02295kendrick_wales_dead_hb.scr (id=2295) ref=0  (evictable)
2026-07-02 01:56:39.189 arcanum-ce[77357:1700621] [refcount DIAG] LOCK   scr\02295kendrick_wales_dead_hb.scr (id=2295) ref=1
2026-07-02 01:56:39.189 arcanum-ce[77357:1700621] [refcount DIAG] UNLOCK scr\02295kendrick_wales_dead_hb.scr (id=2295) ref=0  (evictable)
2026-07-02 01:56:39.189 arcanum-ce[77357:1700621] [refcount DIAG] LOCK   scr\02295kendrick_wales_dead_hb.scr (id=2295) ref=1
2026-07-02 01:56:39.189 arcanum-ce[77357:1700621] [refcount DIAG] UNLOCK scr\02295kendrick_wales_dead_hb.scr (id=2295) ref=0  (evictable)
```

## Testing

Instrumented lock/unlock/evict (the diag commit, removed again in the last commit so the net change is one line).