### PR TITLE
fix(engine): handle Cyrillic / high-byte and over-long text

### DIFF
--- a/first_party/tig/include/tig/str_parse.h
+++ b/first_party/tig/include/tig/str_parse.h
@@ -10,7 +10,7 @@ extern "C" {
 int tig_str_parse_init(TigInitInfo* init_info);
 void tig_str_parse_exit(void);
 void tig_str_parse_set_separator(int sep);
-void tig_str_parse_str_value(char** str, char* value);
+void tig_str_parse_str_value(char** str, char* value, size_t size);
 void tig_str_parse_value(char** str, int* value);
 void tig_str_parse_value_64(char** str, int64_t* value);
 void tig_str_parse_range(char** str, int* start, int* end);
@@ -21,7 +21,7 @@ void tig_str_match_str_to_list(char** str, const char** list, int list_length, i
 void tig_str_parse_flag_list(char** str, const char** keys, const unsigned int* values, int length, unsigned int* value);
 void tig_str_parse_flag_list_64(char** str, const char** keys, const uint64_t* values, int length, uint64_t* value);
 bool tig_str_parse_named_value(char** str, const char* name, int* value);
-bool tig_str_parse_named_str_value(char** str, const char* name, char* value);
+bool tig_str_parse_named_str_value(char** str, const char* name, char* value, size_t size);
 bool tig_str_match_named_str_to_list(char** str, const char* name, const char** list, int list_length, int* value);
 bool tig_str_parse_named_range(char** str, const char* name, int* start, int* end);
 bool tig_str_parse_named_flag_list(char** str, const char* name, const char** keys, const unsigned int* values, int length, unsigned int* value);

--- a/first_party/tig/src/str_parse.c
+++ b/first_party/tig/src/str_parse.c
@@ -33,9 +33,9 @@ void tig_str_parse_set_separator(int sep)
 }
 
 // 0x5318F0
-void tig_str_parse_str_value(char** str, char* value)
+void tig_str_parse_str_value(char** str, char* value, size_t size)
 {
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -44,7 +44,12 @@ void tig_str_parse_str_value(char** str, char* value)
         *sep = '\0';
     }
 
-    memcpy(value, *str, strlen(*str) + 1);
+    size_t len = strlen(*str);
+    if (len >= size) {
+        len = size - 1;
+    }
+    memcpy(value, *str, len);
+    value[len] = '\0';
 
     if (sep != NULL) {
         *sep = tig_str_parse_separator;
@@ -57,7 +62,7 @@ void tig_str_parse_str_value(char** str, char* value)
 // 0x531990
 void tig_str_parse_value(char** str, int* value)
 {
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -79,7 +84,7 @@ void tig_str_parse_value(char** str, int* value)
 // 0x531A20
 void tig_str_parse_value_64(char** str, int64_t* value)
 {
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -101,7 +106,7 @@ void tig_str_parse_value_64(char** str, int64_t* value)
 // 0x531AB0
 void tig_str_parse_range(char** str, int* start, int* end)
 {
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -135,7 +140,7 @@ void tig_str_parse_range(char** str, int* start, int* end)
 // 0x531B70
 void tig_str_parse_complex_value(char** str, int delim, int* value1, int* value2)
 {
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -176,7 +181,7 @@ void tig_str_parse_complex_value(char** str, int delim, int* value1, int* value2
 // 0x531C60
 void tig_str_parse_complex_value3(char** str, int delim, int* value1, int* value2, int* value3)
 {
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -225,7 +230,7 @@ void tig_str_parse_complex_value3(char** str, int delim, int* value1, int* value
 // 0x531D80
 void tig_str_parse_complex_str_value(char** str, int delim, const char** list, int list_length, int* value1, int* value2)
 {
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -289,7 +294,7 @@ void tig_str_parse_complex_str_value(char** str, int delim, const char** list, i
 // 0x531EE0
 void tig_str_match_str_to_list(char** str, const char** list, int list_length, int* value)
 {
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -324,7 +329,7 @@ void tig_str_parse_flag_list(char** str, const char** keys, const unsigned int* 
 {
     *value = 0;
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -379,7 +384,7 @@ void tig_str_parse_flag_list(char** str, const char** keys, const unsigned int* 
                 *str = NULL;
             }
 
-            while (isspace(*(*str))) {
+            while (isspace((unsigned char)*(*str))) {
                 (*str)++;
             }
         }
@@ -398,7 +403,7 @@ void tig_str_parse_flag_list_64(char** str, const char** keys, const uint64_t* v
 {
     *value = 0;
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -453,7 +458,7 @@ void tig_str_parse_flag_list_64(char** str, const char** keys, const uint64_t* v
                 *str = NULL;
             }
 
-            while (isspace(*(*str))) {
+            while (isspace((unsigned char)*(*str))) {
                 (*str)++;
             }
         }
@@ -476,7 +481,7 @@ bool tig_str_parse_named_value(char** str, const char* name, int* value)
         return false;
     }
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -492,14 +497,14 @@ bool tig_str_parse_named_value(char** str, const char* name, int* value)
 }
 
 // 0x5323B0
-bool tig_str_parse_named_str_value(char** str, const char* name, char* value)
+bool tig_str_parse_named_str_value(char** str, const char* name, char* value, size_t size)
 {
     if (*str == NULL) {
         value[0] = '\0';
         return false;
     }
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -510,11 +515,11 @@ bool tig_str_parse_named_str_value(char** str, const char* name, char* value)
 
     *str += strlen(name);
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
-    tig_str_parse_str_value(str, value);
+    tig_str_parse_str_value(str, value, size);
 
     return true;
 }
@@ -527,7 +532,7 @@ bool tig_str_match_named_str_to_list(char** str, const char* name, const char** 
         return false;
     }
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -538,7 +543,7 @@ bool tig_str_match_named_str_to_list(char** str, const char* name, const char** 
 
     *str += strlen(name);
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -556,7 +561,7 @@ bool tig_str_parse_named_range(char** str, const char* name, int* start, int* en
         return false;
     }
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -568,7 +573,7 @@ bool tig_str_parse_named_range(char** str, const char* name, int* start, int* en
 
     *str += strlen(name);
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -586,7 +591,7 @@ bool tig_str_parse_named_flag_list(char** str, const char* name, const char** ke
         return false;
     }
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -596,7 +601,7 @@ bool tig_str_parse_named_flag_list(char** str, const char* name, const char** ke
 
     *str += strlen(name);
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -614,7 +619,7 @@ bool tig_str_parse_named_complex_value(char** str, const char* name, int delim, 
         return false;
     }
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -626,7 +631,7 @@ bool tig_str_parse_named_complex_value(char** str, const char* name, int delim, 
 
     *str += strlen(name);
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -645,7 +650,7 @@ bool tig_str_parse_named_complex_value3(char** str, const char* name, int delim,
         return false;
     }
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -658,7 +663,7 @@ bool tig_str_parse_named_complex_value3(char** str, const char* name, int delim,
 
     *str += strlen(name);
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -676,7 +681,7 @@ bool tig_str_parse_named_complex_str_value(char** str, const char* name, int del
         return false;
     }
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -688,7 +693,7 @@ bool tig_str_parse_named_complex_str_value(char** str, const char* name, int del
 
     *str += strlen(name);
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -706,7 +711,7 @@ bool tig_str_parse_named_flag_list_64(char** str, const char* name, const char**
         return false;
     }
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -716,7 +721,7 @@ bool tig_str_parse_named_flag_list_64(char** str, const char* name, const char**
 
     *str += strlen(name);
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -734,7 +739,7 @@ bool tig_str_parse_named_flag_list_direct(char** str, const char* name, const ch
         return false;
     }
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -754,7 +759,7 @@ void tig_str_parse_flag_list_direct(char** str, const char** keys, int length, u
 {
     *value = 0;
 
-    while (isspace(*(*str))) {
+    while (isspace((unsigned char)*(*str))) {
         (*str)++;
     }
 
@@ -809,7 +814,7 @@ void tig_str_parse_flag_list_direct(char** str, const char** keys, int length, u
                 *str = NULL;
             }
 
-            while (isspace(*(*str))) {
+            while (isspace((unsigned char)*(*str))) {
                 (*str)++;
             }
         }

--- a/src/game/dialog.c
+++ b/src/game/dialog.c
@@ -2819,7 +2819,7 @@ int dialog_file_fclose(TigFile* stream)
 int dialog_file_fgetc(TigFile* stream)
 {
     if (dialog_file_tmp_str_pos != dialog_file_tmp_str_size) {
-        return dialog_file_tmp_str[dialog_file_tmp_str_pos++];
+        return (unsigned char)dialog_file_tmp_str[dialog_file_tmp_str_pos++];
     }
 
     dialog_file_tmp_str_pos = 0;
@@ -2834,7 +2834,7 @@ int dialog_file_fgetc(TigFile* stream)
         return EOF;
     }
 
-    return dialog_file_tmp_str[dialog_file_tmp_str_pos++];
+    return (unsigned char)dialog_file_tmp_str[dialog_file_tmp_str_pos++];
 }
 
 // 0x417E00

--- a/src/game/map.c
+++ b/src/game/map.c
@@ -1618,7 +1618,7 @@ void map_load_extension(const char* base_path)
         str = tmp;
 
         tig_str_parse_set_separator(':');
-        tig_str_parse_str_value(&str, key);
+        tig_str_parse_str_value(&str, key, sizeof(key));
 
         if (SDL_strcasecmp(key, "LightScheme") == 0) {
             tig_str_parse_value(&str, &light_scheme);
@@ -2013,7 +2013,7 @@ bool map_list_info_load(void)
     mes_file_entry.num = 5000;
     while (mes_search(dword_5D11D8, &mes_file_entry)) {
         char* str = mes_file_entry.str;
-        tig_str_parse_str_value(&str, map_list_info[map_list_info_count].name);
+        tig_str_parse_str_value(&str, map_list_info[map_list_info_count].name, sizeof(map_list_info[map_list_info_count].name));
 
         // NOTE: This check is silly. When string it long enough it will easly
         // overrun `MAP_NAME_LENGTH` and crash before this check

--- a/src/game/mes.c
+++ b/src/game/mes.c
@@ -596,7 +596,7 @@ bool parse_field(TigFile* stream, char* buffer)
         }
 
         // Store character in buffer if there's space.
-        if (pos < MAX_STRING) {
+        if (pos < MAX_STRING - 1) {
             buffer[pos++] = (char)ch;
         } else {
             too_long = true;
@@ -661,7 +661,7 @@ int consume_next_char(TigFile* stream)
         }
     }
 
-    return mes_file_parse_buffer[mes_file_parse_pos++];
+    return (unsigned char)mes_file_parse_buffer[mes_file_parse_pos++];
 }
 
 /**

--- a/src/ui/wmap_ui.c
+++ b/src/ui/wmap_ui.c
@@ -1313,7 +1313,7 @@ bool wmap_load_worldmap_info(void)
             }
         }
 
-        tig_str_parse_str_value(&str, wmap_ui_mode_info[WMAP_UI_MODE_WORLD].field_68);
+        tig_str_parse_str_value(&str, wmap_ui_mode_info[WMAP_UI_MODE_WORLD].field_68, sizeof(wmap_ui_mode_info[WMAP_UI_MODE_WORLD].field_68));
 
         if (!wmTileArtLock(0)) {
             tig_debug_printf("wmap_load_worldmap_info: ERROR: wmTileArtLockMode failed!\n");
@@ -1327,7 +1327,7 @@ bool wmap_load_worldmap_info(void)
         wmTileArtUnlock(0);
         wmTileArtUnload(0);
 
-        tig_str_parse_named_str_value(&str, "ZoomedName:", wmap_ui_mode_info[WMAP_UI_MODE_WORLD].str);
+        tig_str_parse_named_str_value(&str, "ZoomedName:", wmap_ui_mode_info[WMAP_UI_MODE_WORLD].str, sizeof(wmap_ui_mode_info[WMAP_UI_MODE_WORLD].str));
 
         dword_66D87C = 0;
         if (tig_str_parse_named_value(&str, "MapKeyedTo:", &map_keyed_to)) {


### PR DESCRIPTION
## Problem

With Cyrillic localization (I am playing with a popular [Expansion 2012 mod](https://arcanumclub.org/workshop/expansion/expansion-2012?start=1)), text data mis-parses. Dialog/mes files load partially or not at all, and long fields abort the game via the stack protector — the game crashes on launch.

## Root cause        

Three related issues with non-ASCII / long text:
1. consume_next_char (mes) and dialog_file_fgetc return a char that is promoted to int. Where char is signed (Apple, incl. arm64), a 0xFF byte becomes -1, which equals EOF —  so the parser treats it as end-of-file and stops reading, truncating the file at the first such byte (0xFF is 'я' in Windows-1251, ubiquitous in Russian text).
2.  parse_field fills a fixed buffer guarded by `pos < MAX_STRING`, then writes buffer[pos] = '\0'; an over-long field writes one past the array end and aborts.
3. tig_str_parse passes a signed char to isspace() and copies a parsed value with an unbounded memcpy that overflows the caller's fixed buffer on long localized values (e.g. map names).

## Fix

1.  Cast bytes to unsigned char before the EOF comparison in the mes/dialog readers.
2. Reserve one byte for the terminator (pos < MAX_STRING - 1).
3.  Cast to unsigned char for isspace(); clamp tig_str_parse_str_value's copy to the destination size, threading the size through its callers.


## Testing

Cyrillic text renders correctly now without game crashing and good news that [mod](https://arcanumclub.org/workshop/expansion/expansion-2012?start=1) is very likely fully supported (still playing and testing mechanics)