### PR TITLE
Add configurable dialogue text scaling and resizable window

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ Several configuration options are available as command-line switches (admittedly
 
 When `HighRes/config.ini` from the Unofficial Arcanum Patch is present in the game directory, Community Edition also imports `Width`, `Height`, `Windowed`, `ShowFPS`, `ScrollFPS`, `ScrollDist`, `Logos`, and `Intro` at startup.
 
+In windowed mode the window is resizable. The framebuffer is scaled with nearest-neighbor filtering, so the picture stays sharp when the window is enlarged.
+
+`DialogScale` (in `HighRes/config.ini`) enlarges conversation text, which is helpful on high-DPI displays where the original bitmap fonts render very small. It accepts a float in the range `1.0` to `3.0` (values above are clamped); `1.0` (the default) keeps the original size. Both the player's dialogue options and the NPC reply are scaled, the reply bubble is widened so long lines wrap sensibly, and the reply is kept clear of the options box to avoid overlap. Example:
+
+```ini
+Width=1024
+Height=768
+Windowed=1
+DialogScale=2.0
+```
+
 ## Contributing
 
 Play the game and file bugs if any (there are likely many). Attach a save game for investigation. Suggestions for quality of life improvements are also welcome. The major objective for 25H2 is to clarify remaining functions.

--- a/first_party/tig/src/font.c
+++ b/first_party/tig/src/font.c
@@ -276,15 +276,30 @@ int tig_font_write(TigVideoBuffer* video_buffer, const char* str, const TigRect*
             int line_width;
             int dx;
             int rc;
+            float sc;
+            int wrap_width;
+            int line_advance;
+
+            if ((tig_font_stack[tig_font_stack_index]->flags & TIG_FONT_SCALE) != 0) {
+                sc = tig_font_stack[tig_font_stack_index]->scale;
+            } else {
+                sc = 1.0f;
+            }
+
+            // Wrapping and line advance are measured in unscaled glyph metrics,
+            // so translate the destination rect into unscaled space for the
+            // wrap width and scale the resulting line height back up.
+            wrap_width = (int)((float)rect->width / sc);
+            line_advance = (int)((float)glyph_height * sc);
 
             while (1) {
-                line_length = sub_535C40(tig_font_stack[tig_font_stack_index]->art_id, remainder, rect->width, &line_width);
+                line_length = sub_535C40(tig_font_stack[tig_font_stack_index]->art_id, remainder, wrap_width, &line_width);
                 if (line_length == -1) {
                     break;
                 }
 
                 if ((tig_font_stack[tig_font_stack_index]->flags & TIG_FONT_CENTERED) != 0) {
-                    dx = (rect->width - line_width) / 2;
+                    dx = (rect->width - (int)((float)line_width * sc)) / 2;
                 } else {
                     dx = 0;
                 }
@@ -293,8 +308,8 @@ int tig_font_write(TigVideoBuffer* video_buffer, const char* str, const TigRect*
                     min_dx = dx;
                 }
 
-                if (line_width > max_width) {
-                    max_width = line_width;
+                if ((int)((float)line_width * sc) > max_width) {
+                    max_width = (int)((float)line_width * sc);
                 }
 
                 dst_rect.x += dx;
@@ -308,17 +323,17 @@ int tig_font_write(TigVideoBuffer* video_buffer, const char* str, const TigRect*
                     return rc;
                 }
 
-                dst_rect.y += glyph_height;
+                dst_rect.y += line_advance;
                 dst_rect.x = dst_rect_x;
 
-                max_y += glyph_height;
+                max_y += line_advance;
 
                 if (remainder[line_length] == '\0') {
                     break;
                 }
 
                 remainder += line_length + 1;
-                if (rect->y + rect->height - max_y < glyph_height) {
+                if (rect->y + rect->height - max_y < line_advance) {
                     break;
                 }
             }

--- a/first_party/tig/src/video.c
+++ b/first_party/tig/src/video.c
@@ -1225,6 +1225,8 @@ bool tig_video_window_create(TigInitInfo* init_info)
     SDL_WindowFlags flags = SDL_WINDOW_HIGH_PIXEL_DENSITY;
     if ((init_info->flags & TIG_INITIALIZE_WINDOWED) == 0) {
         flags |= SDL_WINDOW_FULLSCREEN;
+    } else {
+        flags |= SDL_WINDOW_RESIZABLE;
     }
 
     float scale = SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay());
@@ -1296,6 +1298,8 @@ bool tig_video_window_create(TigInitInfo* init_info)
         SDL_DestroyWindow(window);
         return false;
     }
+
+    SDL_SetTextureScaleMode(texture, SDL_SCALEMODE_NEAREST);
 
     SDL_PropertiesID texture_props = SDL_GetTextureProperties(texture);
     SDL_PixelFormat format = (SDL_PixelFormat)SDL_GetNumberProperty(texture_props, SDL_PROP_TEXTURE_FORMAT_NUMBER, 0);

--- a/src/game/highres_config.c
+++ b/src/game/highres_config.c
@@ -12,6 +12,7 @@ static void highres_config_reset(void);
 static void highres_config_parse_line(char* line);
 static void highres_config_trim(char** start_ptr, char** end_ptr);
 static bool highres_config_parse_int(const char* str, int* value_ptr);
+static bool highres_config_parse_float(const char* str, float* value_ptr);
 
 static HighResConfig highres_config;
 
@@ -52,6 +53,7 @@ void highres_config_reset(void)
     highres_config.scroll_dist = 10;
     highres_config.logos = true;
     highres_config.intro = true;
+    highres_config.dialog_scale = 1.0f;
 }
 
 void highres_config_parse_line(char* line)
@@ -93,6 +95,17 @@ void highres_config_parse_line(char* line)
     value_end = value_start + strlen(value_start);
     highres_config_trim(&value_start, &value_end);
     *value_end = '\0';
+
+    if (SDL_strcasecmp(key_start, "DialogScale") == 0) {
+        float scale;
+        if (highres_config_parse_float(value_start, &scale) && scale >= 1.0f) {
+            if (scale > 3.0f) {
+                scale = 3.0f;
+            }
+            highres_config.dialog_scale = scale;
+        }
+        return;
+    }
 
     if (!highres_config_parse_int(value_start, &value)) {
         return;
@@ -159,5 +172,31 @@ bool highres_config_parse_int(const char* str, int* value_ptr)
     }
 
     *value_ptr = (int)value;
+    return true;
+}
+
+bool highres_config_parse_float(const char* str, float* value_ptr)
+{
+    char* end;
+    float value;
+
+    if (*str == '\0') {
+        return false;
+    }
+
+    value = strtof(str, &end);
+    if (end == str) {
+        return false;
+    }
+
+    while (*end != '\0') {
+        if (!isspace((unsigned char)*end)) {
+            return false;
+        }
+
+        end++;
+    }
+
+    *value_ptr = value;
     return true;
 }

--- a/src/game/highres_config.h
+++ b/src/game/highres_config.h
@@ -13,6 +13,7 @@ typedef struct HighResConfig {
     int scroll_dist;
     bool logos;
     bool intro;
+    float dialog_scale;
 } HighResConfig;
 
 void highres_config_load(void);

--- a/src/game/tb.c
+++ b/src/game/tb.c
@@ -1,7 +1,9 @@
 #include "game/tb.h"
 
 #include "game/gamelib.h"
+#include "game/highres_config.h"
 #include "game/object.h"
+#include "game/tc.h"
 
 /**
  * The maximum number of text bubbles that can be active simultaneously.
@@ -67,6 +69,7 @@ static void tb_text_duration_changed(void);
 static TextBubble* find_text_bubble(int64_t obj);
 static TextBubble* find_free_text_bubble(int64_t obj);
 static void adjust_text_bubble_rect(TigRect* rect, TbPosition pos);
+static void tb_reserve_option_box(void);
 
 /**
  * Color values (RGB) for text bubble types.
@@ -175,6 +178,27 @@ static ViewOptions tb_view_options;
 static tig_font_handle_t tb_fonts[TB_TYPE_COUNT];
 
 /**
+ * Reserves the vertical band occupied by the (possibly enlarged) conversation
+ * option box at the bottom of the iso view, so NPC reply bubbles are placed
+ * above it instead of overlapping the player's dialogue options. No-op unless
+ * dialogue text is scaled up.
+ */
+void tb_reserve_option_box(void)
+{
+    float dialog_scale = highres_config_get()->dialog_scale;
+    int reserved;
+
+    if (dialog_scale <= 1.0f) {
+        return;
+    }
+
+    reserved = tc_reserved_height(dialog_scale);
+    if (reserved < tb_iso_content_rect.height) {
+        tb_iso_content_rect.height -= reserved;
+    }
+}
+
+/**
  * Called when the game is initialized.
  *
  * 0x4D5B80
@@ -198,16 +222,30 @@ bool tb_init(GameInitInfo* init_info)
     tb_iso_content_rect.y = 0;
     tb_iso_content_rect.width = window_data.rect.width;
     tb_iso_content_rect.height = window_data.rect.height;
+    tb_reserve_option_box();
 
     tb_view_options.type = VIEW_TYPE_ISOMETRIC;
 
     tb_enabled = true;
     tb_background_color = tig_color_make(0, 0, 255);
 
-    // Set up video buffer creation parameters.
+    // Set up video buffer creation parameters. When dialogue text is enlarged,
+    // widen the bubble so long replies wrap into fewer, wider lines instead of
+    // a tall narrow column. The wrap width is a fraction of the view width so it
+    // never exceeds the screen regardless of scale, and the height grows with
+    // the scale to hold the taller lines.
+    if (highres_config_get()->dialog_scale > 1.0f) {
+        float ds = highres_config_get()->dialog_scale;
+        int wide = (int)(window_data.rect.width * 0.75f);
+        if (wide > tb_content_rect.width) {
+            tb_content_rect.width = wide;
+        }
+        tb_content_rect.height = (int)(TEXT_BUBBLE_HEIGHT * ds + 0.5f);
+    }
+
     vb_create_info.flags = TIG_VIDEO_BUFFER_CREATE_SYSTEM_MEMORY | TIG_VIDEO_BUFFER_CREATE_COLOR_KEY;
-    vb_create_info.width = TEXT_BUBBLE_WIDTH;
-    vb_create_info.height = TEXT_BUBBLE_HEIGHT;
+    vb_create_info.width = tb_content_rect.width;
+    vb_create_info.height = tb_content_rect.height;
     vb_create_info.background_color = tb_background_color;
     vb_create_info.color_key = tb_background_color;
 
@@ -229,6 +267,12 @@ bool tb_init(GameInitInfo* init_info)
     // Set up font creation parameters.
     font.flags = TIG_FONT_NO_ALPHA_BLEND | TIG_FONT_CENTERED | TIG_FONT_SHADOW;
     tig_art_interface_id_create(229, 0, 0, 0, &(font.art_id));
+
+    // Enlarge dialogue text when requested via `DialogScale`.
+    if (highres_config_get()->dialog_scale > 1.0f) {
+        font.flags |= TIG_FONT_SCALE;
+        font.scale = highres_config_get()->dialog_scale;
+    }
 
     // Create fonts for each text bubble type with appropriate colors.
     for (idx = 0; idx < TB_TYPE_COUNT; idx++) {
@@ -288,6 +332,7 @@ void tb_resize(GameResizeInfo* resize_info)
 {
     tb_iso_content_rect = resize_info->content_rect;
     tb_iso_window_handle = resize_info->window_handle;
+    tb_reserve_option_box();
 }
 
 /**

--- a/src/game/tc.c
+++ b/src/game/tc.c
@@ -1,5 +1,7 @@
 #include "game/tc.h"
 
+#include "game/highres_config.h"
+
 /**
  * The number of lines in the text conversation.
  */
@@ -14,6 +16,17 @@
  * Vertical space between between lines (in pixels).
  */
 #define TEXT_CONVERSATION_VERT_SPACING 3
+
+/**
+ * Unscaled height of the conversation option box (in pixels).
+ */
+#define TEXT_CONVERSATION_BOX_HEIGHT 100
+
+/**
+ * Distance from the bottom of the iso view to the option box in non-compact
+ * mode (in pixels).
+ */
+#define TEXT_CONVERSATION_BOTTOM_OFFSET 159
 
 static void tc_render_internal(TigRectListNode* node);
 
@@ -91,6 +104,12 @@ static TigVideoBuffer* tc_backdrop_video_buffer;
 static int tc_line_height;
 
 /**
+ * Scale factor applied to conversation text and its geometry when the
+ * `DialogScale` config option is greater than 1.0.
+ */
+static float tc_scale = 1.0f;
+
+/**
  * Flag indicating some internal state which is never set. Its exact meaning is
  * unclear.
  *
@@ -166,11 +185,18 @@ bool tc_init(GameInitInfo* init_info)
 
     tc_iso_window_rect = window_data.rect;
 
-    // Set up the intermediate video buffers' rect.
+    // Enlarge conversation text when requested via `DialogScale`.
+    tc_scale = highres_config_get()->dialog_scale;
+    if (tc_scale < 1.0f) {
+        tc_scale = 1.0f;
+    }
+
+    // Set up the intermediate video buffers' rect. Height scales with the text
+    // so enlarged option lines are not clipped.
     tc_intermediate_video_buffer_rect.x = 0;
     tc_intermediate_video_buffer_rect.y = 0;
     tc_intermediate_video_buffer_rect.width = window_data.rect.width;
-    tc_intermediate_video_buffer_rect.height = 100;
+    tc_intermediate_video_buffer_rect.height = (int)(TEXT_CONVERSATION_BOX_HEIGHT * tc_scale + 0.5f);
 
     // Create the scratch video buffer for rendering text (color keyed for
     // transparency).
@@ -197,6 +223,12 @@ bool tc_init(GameInitInfo* init_info)
     tig_art_interface_id_create(229, 0, 0, 0, &art_id);
     font.flags = TIG_FONT_SHADOW;
     font.art_id = art_id;
+
+    // Enlarge conversation text when requested.
+    if (tc_scale > 1.0f) {
+        font.flags |= TIG_FONT_SCALE;
+        font.scale = tc_scale;
+    }
 
     // Create white font for normal text.
     font.color = tig_color_make(255, 255, 255);
@@ -411,14 +443,16 @@ void tc_clear(bool compact)
 
     // Set default content size and center it horizontally.
     tc_content_rect.width = 400;
-    tc_content_rect.height = 100;
+    tc_content_rect.height = tc_intermediate_video_buffer_rect.height;
     tc_content_rect.x = (tc_iso_window_rect.width - tc_content_rect.width) / 2;
 
-    // Adjust vertical position depending on normal vs. compact mode.
+    // Adjust vertical position depending on normal vs. compact mode. The extra
+    // scaled height is subtracted so the taller box grows upward from its
+    // original baseline instead of overrunning the bottom UI.
     if (compact) {
         tc_content_rect.y = tc_iso_window_rect.height - tc_content_rect.height - 37;
     } else {
-        tc_content_rect.y = tc_iso_window_rect.height - tc_content_rect.height - 159;
+        tc_content_rect.y = tc_iso_window_rect.height - tc_content_rect.height - TEXT_CONVERSATION_BOTTOM_OFFSET;
     }
 }
 
@@ -607,6 +641,15 @@ int tc_check_size(const char* str)
     }
 
     return width;
+}
+
+int tc_reserved_height(float dialog_scale)
+{
+    if (dialog_scale < 1.0f) {
+        dialog_scale = 1.0f;
+    }
+
+    return (int)(TEXT_CONVERSATION_BOX_HEIGHT * dialog_scale + 0.5f) + TEXT_CONVERSATION_BOTTOM_OFFSET;
 }
 
 /**

--- a/src/game/tc.h
+++ b/src/game/tc.h
@@ -15,4 +15,11 @@ void tc_set_option(int index, const char* str);
 int tc_handle_message(TigMessage* msg);
 int tc_check_size(const char* str);
 
+/**
+ * Returns the height (in pixels) reserved at the bottom of the iso view by the
+ * conversation option box for the given dialogue scale. Used by the text bubble
+ * module to avoid overlapping enlarged dialogue options.
+ */
+int tc_reserved_height(float dialog_scale);
+
 #endif /* ARCANUM_GAME_TC_H_ */


### PR DESCRIPTION
**NOTE: This is hardly tested**

On high-DPI displays the original bitmap fonts render very small. Add options to enlarge conversation text and to resize the window.

- Make the windowed-mode window resizable and switch the framebuffer present to nearest-neighbor filtering so upscaled output stays sharp.
- Add a DialogScale option to HighRes/config.ini (float, clamped to 1.0-3.0; 1.0 default keeps original behavior).
- Honor TIG_FONT_SCALE in the text renderer's wrap width, line advance, and centering, which were previously measured in unscaled metrics. Only fonts that set the flag are affected.
- Scale the player option box (tc) font and geometry together; scale and widen the NPC reply bubble (tb) so long replies wrap sensibly.
- Reserve the option-box band in the bubble placement area, on both init and resize, so the reply no longer overlaps the options. Share the box geometry via tc_reserved_height instead of duplicating constants.
- Document the new options in the README.