### PR TITLE
fix: NPCs turn hostile on first interaction instead of applying their scripted reaction

### DIFF
--- a/src/game/script.c
+++ b/src/game/script.c
@@ -1726,7 +1726,7 @@ int script_execute_action(ScriptAction* action, int line, ScriptState* state)
     case SAT_SET_REACTION: {
         int64_t npc_obj = script_get_obj(action->op_type[0], action->op_value[0], state);
         int64_t pc_obj = script_get_obj(action->op_type[1], action->op_value[1], state);
-        int reaction = script_get_value(action->op_type[2], action->op_value[1], state);
+        int reaction = script_get_value(action->op_type[2], action->op_value[2], state);
         reaction_adj(npc_obj, pc_obj, reaction - reaction_get(npc_obj, pc_obj));
         return NEXT;
     }


### PR DESCRIPTION
## Problem

When interacting with an NPC whose script sets a custom reaction on first contact (e.g. Edmund Craig, the Master Backstab trainer), the NPC immediately turns hostile and attacks — even though the script specifies a different, non-hostile value. For Craig this makes Master Backstab training impossible: clicking him starts a fight instead of opening the dialog.

## Root cause

`SAT_SET_REACTION` reads the reaction value from `op_value[1]` — the PC (Triggerer) operand slot — instead of `op_value[2]`, the value operand. Object operands are picked by focus type and carry no meaningful number in their value slot (it holds 0, or uninitialized garbage), so set reaction to X sets the reaction to that junk (~0) instead of X. The neighboring `SAT_GET_REACTION` and `SAT_ADJUST_REACTION` cases use `op_value[2]` correctly.

For Craig specifically: his dialog script sets the reaction to 40, but the bug forces it to 0 and he attacks before the dialog opens.

## Fix

Read `op_value[2]` (the action's own value operand) instead of `op_value[1]`.
E.g. Craig's reaction now resolves to 40 and the dialog opens normally.

